### PR TITLE
feat: mux MP4 export via ffmpeg H.264 stream and add error-only logs

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -78,10 +78,18 @@ fn main() {
         "write_export_chunk",
         "finish_export",
         "abort_export",
+        "begin_export_h264_stream",
+        "write_export_h264_chunk",
+        "finish_export_h264_stream",
+        "abort_export_h264_stream",
         "mux_export_audio",
         "prepare_export_audio",
         "attach_export_audio",
         "remove_temp_file",
+        // error log
+        "log_client_error",
+        "reveal_error_log",
+        "error_log_path",
         // updater
         "check_for_updates",
     ];

--- a/src-tauri/capabilities/core.json
+++ b/src-tauri/capabilities/core.json
@@ -11,5 +11,9 @@
     "area-picker",
     "area-frame"
   ],
-  "permissions": ["core:default"]
+  "permissions": [
+    "core:default",
+    "allow-log-client-error",
+    "allow-error-log-path"
+  ]
 }

--- a/src-tauri/capabilities/editor.json
+++ b/src-tauri/capabilities/editor.json
@@ -36,11 +36,16 @@
     "allow-write-export-chunk",
     "allow-finish-export",
     "allow-abort-export",
+    "allow-begin-export-h264-stream",
+    "allow-write-export-h264-chunk",
+    "allow-finish-export-h264-stream",
+    "allow-abort-export-h264-stream",
     "allow-mux-export-audio",
     "allow-prepare-export-audio",
     "allow-attach-export-audio",
     "allow-remove-temp-file",
     "allow-present-window",
-    "allow-open-editor"
+    "allow-open-editor",
+    "allow-reveal-error-log"
   ]
 }

--- a/src-tauri/capabilities/recorder.json
+++ b/src-tauri/capabilities/recorder.json
@@ -45,6 +45,7 @@
     "allow-open-library",
     "allow-open-editor",
     "allow-check-for-updates",
+    "allow-reveal-error-log",
     "notification:allow-is-permission-granted"
   ]
 }

--- a/src-tauri/permissions/autogenerated/abort_export_h264_stream.toml
+++ b/src-tauri/permissions/autogenerated/abort_export_h264_stream.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-abort-export-h264-stream"
+description = "Enables the abort_export_h264_stream command without any pre-configured scope."
+commands.allow = ["abort_export_h264_stream"]
+
+[[permission]]
+identifier = "deny-abort-export-h264-stream"
+description = "Denies the abort_export_h264_stream command without any pre-configured scope."
+commands.deny = ["abort_export_h264_stream"]

--- a/src-tauri/permissions/autogenerated/begin_export_h264_stream.toml
+++ b/src-tauri/permissions/autogenerated/begin_export_h264_stream.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-begin-export-h264-stream"
+description = "Enables the begin_export_h264_stream command without any pre-configured scope."
+commands.allow = ["begin_export_h264_stream"]
+
+[[permission]]
+identifier = "deny-begin-export-h264-stream"
+description = "Denies the begin_export_h264_stream command without any pre-configured scope."
+commands.deny = ["begin_export_h264_stream"]

--- a/src-tauri/permissions/autogenerated/error_log_path.toml
+++ b/src-tauri/permissions/autogenerated/error_log_path.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-error-log-path"
+description = "Enables the error_log_path command without any pre-configured scope."
+commands.allow = ["error_log_path"]
+
+[[permission]]
+identifier = "deny-error-log-path"
+description = "Denies the error_log_path command without any pre-configured scope."
+commands.deny = ["error_log_path"]

--- a/src-tauri/permissions/autogenerated/finish_export_h264_stream.toml
+++ b/src-tauri/permissions/autogenerated/finish_export_h264_stream.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-finish-export-h264-stream"
+description = "Enables the finish_export_h264_stream command without any pre-configured scope."
+commands.allow = ["finish_export_h264_stream"]
+
+[[permission]]
+identifier = "deny-finish-export-h264-stream"
+description = "Denies the finish_export_h264_stream command without any pre-configured scope."
+commands.deny = ["finish_export_h264_stream"]

--- a/src-tauri/permissions/autogenerated/log_client_error.toml
+++ b/src-tauri/permissions/autogenerated/log_client_error.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-log-client-error"
+description = "Enables the log_client_error command without any pre-configured scope."
+commands.allow = ["log_client_error"]
+
+[[permission]]
+identifier = "deny-log-client-error"
+description = "Denies the log_client_error command without any pre-configured scope."
+commands.deny = ["log_client_error"]

--- a/src-tauri/permissions/autogenerated/reveal_error_log.toml
+++ b/src-tauri/permissions/autogenerated/reveal_error_log.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-reveal-error-log"
+description = "Enables the reveal_error_log command without any pre-configured scope."
+commands.allow = ["reveal_error_log"]
+
+[[permission]]
+identifier = "deny-reveal-error-log"
+description = "Denies the reveal_error_log command without any pre-configured scope."
+commands.deny = ["reveal_error_log"]

--- a/src-tauri/permissions/autogenerated/write_export_h264_chunk.toml
+++ b/src-tauri/permissions/autogenerated/write_export_h264_chunk.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-write-export-h264-chunk"
+description = "Enables the write_export_h264_chunk command without any pre-configured scope."
+commands.allow = ["write_export_h264_chunk"]
+
+[[permission]]
+identifier = "deny-write-export-h264-chunk"
+description = "Denies the write_export_h264_chunk command without any pre-configured scope."
+commands.deny = ["write_export_h264_chunk"]

--- a/src-tauri/src/commands/error_log.rs
+++ b/src-tauri/src/commands/error_log.rs
@@ -1,0 +1,33 @@
+//! Client error log IPC — JS + tray “Open Error Log…”.
+
+use crate::error::AppResult;
+use crate::error_log;
+use tauri::AppHandle;
+
+/// Append a frontend error to the on-disk error log (errors only).
+#[tauri::command(async)]
+pub fn log_client_error(source: String, message: String) -> AppResult<()> {
+    if message.trim().is_empty() {
+        return Ok(());
+    }
+    let src = if source.trim().is_empty() {
+        "js"
+    } else {
+        source.trim()
+    };
+    error_log::append(src, &message);
+    Ok(())
+}
+
+/// Reveal `logs/errors.log` in Finder / Explorer.
+#[tauri::command(async)]
+pub fn reveal_error_log(_app: AppHandle) -> AppResult<String> {
+    let path = error_log::reveal()?;
+    Ok(path.to_string_lossy().into_owned())
+}
+
+/// Absolute path of the error log (may not exist yet).
+#[tauri::command]
+pub fn error_log_path() -> AppResult<String> {
+    Ok(error_log::log_path().to_string_lossy().into_owned())
+}

--- a/src-tauri/src/commands/export.rs
+++ b/src-tauri/src/commands/export.rs
@@ -6,6 +6,7 @@
 //! Tauri's event loop (spinning beachball).
 
 use crate::error::{AppError, AppResult};
+use crate::export_h264::H264StreamMuxer;
 use crate::recorder::encoder::{
     attach_export_audio as run_attach_export_audio,
     mux_export_audio as run_mux_export_audio,
@@ -290,9 +291,81 @@ fn finish_export_blocking(sink: ExportSink) -> AppResult<String> {
 #[tauri::command(async)]
 pub fn abort_export(state: State<AppState>, handle: u64, reason: String) -> AppResult<()> {
     if let Some(sink) = state.exports.lock().remove(&handle) {
-        tracing::info!(handle, %reason, "export aborted");
+        tracing::error!(handle, %reason, "export aborted");
         drop(sink.file);
         let _ = std::fs::remove_file(&sink.path);
+    }
+    Ok(())
+}
+
+// --- Annex-B H.264 → ffmpeg MP4 (out-of-webview mux) -------------------------
+
+/// Start ffmpeg reading Annex-B H.264 from IPC writes; output is a temp MP4
+/// promoted on [`finish_export_h264_stream`].
+#[tauri::command(async)]
+pub fn begin_export_h264_stream(
+    state: State<AppState>,
+    path: String,
+    fps: u32,
+) -> AppResult<u64> {
+    let final_path = PathBuf::from(path);
+    let muxer = H264StreamMuxer::spawn(&final_path, fps)?;
+    let mut next = state.next_export_id.lock();
+    let handle = *next;
+    *next += 1;
+    drop(next);
+    state.h264_exports.lock().insert(handle, muxer);
+    Ok(handle)
+}
+
+const H264_HANDLE_HEADER: &str = "x-export-handle";
+
+/// Append one Annex-B chunk to the ffmpeg stdin pipe.
+#[tauri::command(async)]
+pub fn write_export_h264_chunk(
+    state: State<AppState>,
+    request: tauri::ipc::Request<'_>,
+) -> AppResult<()> {
+    let handle = export_header(&request, H264_HANDLE_HEADER)?;
+    let tauri::ipc::InvokeBody::Raw(chunk) = request.body() else {
+        return Err(AppError::Other(
+            "write_export_h264_chunk expects a raw byte body".into(),
+        ));
+    };
+    let mut exports = state.h264_exports.lock();
+    let muxer = exports
+        .get_mut(&handle)
+        .ok_or_else(|| AppError::Other(format!("unknown h264 export handle {handle}")))?;
+    muxer.write_chunk(chunk)
+}
+
+#[tauri::command]
+pub async fn finish_export_h264_stream(
+    state: State<'_, AppState>,
+    handle: u64,
+) -> AppResult<String> {
+    let muxer = state
+        .h264_exports
+        .lock()
+        .remove(&handle)
+        .ok_or_else(|| AppError::Other(format!("unknown h264 export handle {handle}")))?;
+    tauri::async_runtime::spawn_blocking(move || {
+        let path = muxer.finish()?;
+        Ok(path.to_string_lossy().into_owned())
+    })
+    .await
+    .map_err(|e| AppError::Other(format!("h264 export finish task failed: {e}")))?
+}
+
+#[tauri::command(async)]
+pub fn abort_export_h264_stream(
+    state: State<AppState>,
+    handle: u64,
+    reason: String,
+) -> AppResult<()> {
+    if let Some(muxer) = state.h264_exports.lock().remove(&handle) {
+        tracing::error!(handle, %reason, "h264 export aborted");
+        muxer.abort();
     }
     Ok(())
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod backgrounds;
 pub mod captions;
+pub mod error_log;
 pub mod export;
 pub mod project;
 pub mod recording;
@@ -87,10 +88,18 @@ macro_rules! command_handlers {
             $crate::commands::export::write_export_chunk,
             $crate::commands::export::finish_export,
             $crate::commands::export::abort_export,
+            $crate::commands::export::begin_export_h264_stream,
+            $crate::commands::export::write_export_h264_chunk,
+            $crate::commands::export::finish_export_h264_stream,
+            $crate::commands::export::abort_export_h264_stream,
             $crate::commands::export::mux_export_audio,
             $crate::commands::export::prepare_export_audio,
             $crate::commands::export::attach_export_audio,
             $crate::commands::export::remove_temp_file,
+            // error log (friend-install diagnostics)
+            $crate::commands::error_log::log_client_error,
+            $crate::commands::error_log::reveal_error_log,
+            $crate::commands::error_log::error_log_path,
             // updater
             $crate::updater::check_for_updates,
         ]

--- a/src-tauri/src/error_log.rs
+++ b/src-tauri/src/error_log.rs
@@ -1,0 +1,279 @@
+//! Error-only persistent log for friend installs / support.
+//!
+//! Path: `{app_data}/logs/errors.log` (Windows: `%APPDATA%\com.capptivo.desktop\logs\errors.log`).
+//! Captures `tracing::error!`, Rust panics, and JS `log_client_error` — never info/warn.
+
+use crate::error::{AppError, AppResult};
+use parking_lot::Mutex;
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use tracing::field::{Field, Visit};
+use tracing::{Event, Level, Subscriber};
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::Layer;
+
+const APP_ID: &str = "com.capptivo.desktop";
+const LOG_NAME: &str = "errors.log";
+/// Soft cap — rewrite keeping the tail when exceeded.
+const MAX_BYTES: u64 = 2 * 1024 * 1024;
+const KEEP_TAIL: u64 = 512 * 1024;
+
+static LOG_PATH: OnceLock<PathBuf> = OnceLock::new();
+static WRITE_LOCK: Mutex<()> = Mutex::new(());
+
+/// Resolve + create the log file; install panic hook. Safe to call once at boot.
+pub fn init() {
+    let path = default_log_path();
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    let _ = LOG_PATH.set(path);
+    let _ = ensure_file();
+
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let loc = info
+            .location()
+            .map(|l| format!("{}:{}:{}", l.file(), l.line(), l.column()))
+            .unwrap_or_else(|| "unknown".into());
+        let payload = if let Some(s) = info.payload().downcast_ref::<&str>() {
+            (*s).to_string()
+        } else if let Some(s) = info.payload().downcast_ref::<String>() {
+            s.clone()
+        } else {
+            "Box<Any>".into()
+        };
+        append("panic", &format!("{payload} @ {loc}"));
+        previous(info);
+    }));
+}
+
+pub fn log_path() -> PathBuf {
+    LOG_PATH.get().cloned().unwrap_or_else(default_log_path)
+}
+
+/// Append one error line. Never panics; failures are silent.
+pub fn append(source: &str, message: &str) {
+    let msg = message.trim();
+    if msg.is_empty() {
+        return;
+    }
+    let line = format!(
+        "{} ERROR [{}] {}\n",
+        chrono::Utc::now().format("%Y-%m-%dT%H:%M:%S%.3fZ"),
+        sanitize(source),
+        sanitize_message(msg),
+    );
+    let _guard = WRITE_LOCK.lock();
+    let path = log_path();
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    rotate_if_huge(&path);
+    if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(&path) {
+        let _ = file.write_all(line.as_bytes());
+        let _ = file.flush();
+    }
+}
+
+/// Reveal `errors.log` in the OS file manager. Creates an empty file if missing.
+pub fn reveal() -> AppResult<PathBuf> {
+    let path = ensure_file()?;
+    opener_reveal(&path)?;
+    Ok(path)
+}
+
+fn ensure_file() -> AppResult<PathBuf> {
+    let path = log_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    if !path.exists() {
+        File::create(&path)?;
+    }
+    Ok(path)
+}
+
+fn default_log_path() -> PathBuf {
+    app_data_root().join("logs").join(LOG_NAME)
+}
+
+fn app_data_root() -> PathBuf {
+    #[cfg(target_os = "windows")]
+    {
+        if let Some(appdata) = std::env::var_os("APPDATA") {
+            return PathBuf::from(appdata).join(APP_ID);
+        }
+    }
+    #[cfg(target_os = "macos")]
+    {
+        if let Some(home) = std::env::var_os("HOME") {
+            return PathBuf::from(home)
+                .join("Library")
+                .join("Application Support")
+                .join(APP_ID);
+        }
+    }
+    #[cfg(target_os = "linux")]
+    {
+        if let Some(xdg) = std::env::var_os("XDG_DATA_HOME") {
+            return PathBuf::from(xdg).join(APP_ID);
+        }
+        if let Some(home) = std::env::var_os("HOME") {
+            return PathBuf::from(home)
+                .join(".local")
+                .join("share")
+                .join(APP_ID);
+        }
+    }
+    std::env::temp_dir().join("Capptivo").join(APP_ID)
+}
+
+fn rotate_if_huge(path: &Path) {
+    let Ok(meta) = fs::metadata(path) else {
+        return;
+    };
+    if meta.len() <= MAX_BYTES {
+        return;
+    }
+    let Ok(data) = fs::read(path) else {
+        return;
+    };
+    let start = data.len().saturating_sub(KEEP_TAIL as usize);
+    let mut tail = data[start..].to_vec();
+    if let Some(i) = tail.iter().position(|&b| b == b'\n') {
+        tail = tail[i + 1..].to_vec();
+    }
+    let _ = fs::write(path, tail);
+}
+
+fn sanitize(s: &str) -> String {
+    s.chars()
+        .map(|c| if c.is_control() { ' ' } else { c })
+        .take(64)
+        .collect()
+}
+
+fn sanitize_message(s: &str) -> String {
+    s.chars()
+        .map(|c| match c {
+            '\n' | '\r' => ' ',
+            c if c.is_control() => ' ',
+            c => c,
+        })
+        .take(4000)
+        .collect()
+}
+
+fn opener_reveal(path: &Path) -> AppResult<()> {
+    #[cfg(target_os = "macos")]
+    {
+        std::process::Command::new("open")
+            .args(["-R"])
+            .arg(path)
+            .spawn()
+            .map_err(|e| AppError::Other(format!("reveal log failed: {e}")))?;
+        return Ok(());
+    }
+    #[cfg(target_os = "windows")]
+    {
+        // `explorer /select,path` highlights the file.
+        std::process::Command::new("explorer")
+            .arg(format!("/select,{}", path.display()))
+            .spawn()
+            .map_err(|e| AppError::Other(format!("reveal log failed: {e}")))?;
+        return Ok(());
+    }
+    #[cfg(target_os = "linux")]
+    {
+        if let Some(parent) = path.parent() {
+            std::process::Command::new("xdg-open")
+                .arg(parent)
+                .spawn()
+                .map_err(|e| AppError::Other(format!("reveal log failed: {e}")))?;
+        }
+        return Ok(());
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+    {
+        let _ = path;
+        Err(AppError::Unsupported)
+    }
+}
+
+/// Tracing layer: only [`Level::ERROR`] events hit the file.
+pub struct ErrorFileLayer;
+
+impl<S> Layer<S> for ErrorFileLayer
+where
+    S: Subscriber,
+{
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        if *event.metadata().level() != Level::ERROR {
+            return;
+        }
+        let mut visitor = ErrorVisitor::default();
+        event.record(&mut visitor);
+        let target = event.metadata().target();
+        let msg = if visitor.message.is_empty() {
+            visitor.fields
+        } else if visitor.fields.is_empty() {
+            visitor.message
+        } else {
+            format!("{} {}", visitor.message, visitor.fields)
+        };
+        append(target, &msg);
+    }
+}
+
+#[derive(Default)]
+struct ErrorVisitor {
+    message: String,
+    fields: String,
+}
+
+impl Visit for ErrorVisitor {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "message" {
+            self.message = value.to_string();
+        } else {
+            self.push_field(field.name(), value);
+        }
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            self.message = format!("{value:?}");
+            // Prefer unquoted Display-ish for String debug
+            if self.message.starts_with('"') && self.message.ends_with('"') && self.message.len() >= 2
+            {
+                self.message = self.message[1..self.message.len() - 1].to_string();
+            }
+        } else {
+            self.push_field(field.name(), &format!("{value:?}"));
+        }
+    }
+}
+
+impl ErrorVisitor {
+    fn push_field(&mut self, name: &str, value: &str) {
+        if !self.fields.is_empty() {
+            self.fields.push(' ');
+        }
+        self.fields.push_str(name);
+        self.fields.push('=');
+        self.fields.push_str(value);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_strips_newlines() {
+        assert!(!sanitize_message("a\nb\rc").contains('\n'));
+    }
+}

--- a/src-tauri/src/export_h264.rs
+++ b/src-tauri/src/export_h264.rs
@@ -1,0 +1,283 @@
+//! Stream-copy muxer: Annex-B H.264 on stdin → MP4 via the ffmpeg sidecar.
+//!
+//! The editor WebView composes with Pixi and encodes with WebCodecs; Rust only
+//! runs `ffmpeg -f h264 -i pipe:0 -c:v copy` so mux/IO stay out of WebView2
+//! (the Windows export failure mode when mediabunny muxes in-process).
+
+use crate::error::{AppError, AppResult};
+use crate::proc;
+use crate::recorder::encoder::ffmpeg_path;
+use std::io::{BufRead, BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStderr, ChildStdin, Stdio};
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+const FFMPEG_FINISH_TIMEOUT: Duration = Duration::from_secs(60);
+const FFMPEG_STDERR_CAP: usize = 64 * 1024;
+
+/// Live ffmpeg session writing a partial MP4 beside the user destination.
+pub struct H264StreamMuxer {
+    child: Child,
+    stdin: Option<BufWriter<ChildStdin>>,
+    stderr_text: Arc<Mutex<String>>,
+    stderr_reader: Option<JoinHandle<()>>,
+    temp_path: PathBuf,
+    final_path: PathBuf,
+    bytes_written: u64,
+    /// Set when `finish` / `abort` already cleaned up — skip [`Drop`] teardown.
+    settled: bool,
+}
+
+impl H264StreamMuxer {
+    pub fn spawn(final_path: &Path, fps: u32) -> AppResult<Self> {
+        let temp_path = export_temp_path(final_path);
+        if temp_path.exists() {
+            let _ = std::fs::remove_file(&temp_path);
+        }
+
+        let ffmpeg = ffmpeg_path();
+        let fps = fps.max(1);
+        let fps_s = fps.to_string();
+        // WebCodecs/VideoToolbox embeds VUI timing that the raw h264 demuxer
+        // trusts over `-framerate`, producing ~700fps / sub-second duration.
+        // Rewrite PTS/DTS/duration from the known CFR so the MP4 matches frame count.
+        let bsf = format!("setts=pts=N/TB/{fps}:dts=N/TB/{fps}:duration=1/TB/{fps}");
+        let timescale_s = (fps * 1000).to_string();
+        let mut child = proc::command(&ffmpeg)
+            .args([
+                "-y",
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-f",
+                "h264",
+                "-framerate",
+                &fps_s,
+                "-raw_packet_size",
+                "1048576",
+                "-i",
+                "pipe:0",
+                "-an",
+                "-c:v",
+                "copy",
+                "-bsf:v",
+                &bsf,
+                "-video_track_timescale",
+                &timescale_s,
+                // Temp path ends in `.partial`, not `.mp4` — force the muxer.
+                "-f",
+                "mp4",
+            ])
+            .arg(&temp_path)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| {
+                AppError::Encoder(format!(
+                    "could not start ffmpeg h264 mux ({}): {e}",
+                    ffmpeg.display()
+                ))
+            })?;
+
+        let raw_stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| AppError::Encoder("ffmpeg stdin missing".into()))?;
+        let stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| AppError::Encoder("ffmpeg stderr missing".into()))?;
+        let stderr_text = Arc::new(Mutex::new(String::new()));
+        let stderr_reader = std::thread::Builder::new()
+            .name("ffmpeg-h264-stderr".into())
+            .spawn({
+                let buf = stderr_text.clone();
+                move || drain_stderr(stderr, buf)
+            })
+            .ok();
+
+        Ok(Self {
+            child,
+            stdin: Some(BufWriter::with_capacity(256 * 1024, raw_stdin)),
+            stderr_text,
+            stderr_reader,
+            temp_path,
+            final_path: final_path.to_path_buf(),
+            bytes_written: 0,
+            settled: false,
+        })
+    }
+
+    pub fn write_chunk(&mut self, chunk: &[u8]) -> AppResult<()> {
+        if chunk.is_empty() {
+            return Ok(());
+        }
+        let stdin = self
+            .stdin
+            .as_mut()
+            .ok_or_else(|| AppError::Encoder("ffmpeg stdin already closed".into()))?;
+        if let Err(e) = stdin.write_all(chunk).and_then(|_| stdin.flush()) {
+            let stderr = self.stderr_snapshot();
+            let child_status = match self.child.try_wait() {
+                Ok(Some(status)) => format!("exited {status}"),
+                Ok(None) => "still running".into(),
+                Err(err) => format!("status error: {err}"),
+            };
+            return Err(AppError::Encoder(format!(
+                "ffmpeg h264 write failed: {e} ({child_status}){stderr_suffix}",
+                stderr_suffix = if stderr.is_empty() {
+                    String::new()
+                } else {
+                    format!("; {stderr}")
+                }
+            )));
+        }
+        self.bytes_written += chunk.len() as u64;
+        Ok(())
+    }
+
+    /// Close stdin, wait for ffmpeg, promote temp → final. Returns final path.
+    pub fn finish(mut self) -> AppResult<PathBuf> {
+        if let Some(mut stdin) = self.stdin.take() {
+            let _ = stdin.flush();
+            drop(stdin);
+        }
+        let status = wait_child(&mut self.child, FFMPEG_FINISH_TIMEOUT)?;
+        if let Some(handle) = self.stderr_reader.take() {
+            let _ = handle.join();
+        }
+        if !status.success() {
+            let err = self.stderr_snapshot();
+            let _ = std::fs::remove_file(&self.temp_path);
+            return Err(AppError::Encoder(format!(
+                "ffmpeg h264 mux exited with {status}: {err}"
+            )));
+        }
+        if self.bytes_written < 64 {
+            let _ = std::fs::remove_file(&self.temp_path);
+            return Err(AppError::Encoder(
+                "ffmpeg h264 mux produced an empty video".into(),
+            ));
+        }
+        promote_temp_to_final(&self.temp_path, &self.final_path)?;
+        self.settled = true;
+        Ok(self.final_path.clone())
+    }
+
+    pub fn abort(mut self) {
+        self.stdin.take();
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        if let Some(handle) = self.stderr_reader.take() {
+            let _ = handle.join();
+        }
+        let _ = std::fs::remove_file(&self.temp_path);
+        self.settled = true;
+    }
+
+    fn stderr_snapshot(&self) -> String {
+        self.stderr_text
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+    }
+}
+
+impl Drop for H264StreamMuxer {
+    fn drop(&mut self) {
+        if self.settled {
+            return;
+        }
+        self.stdin.take();
+        if matches!(self.child.try_wait(), Ok(None)) {
+            let _ = self.child.kill();
+            let _ = self.child.wait();
+        }
+        let _ = std::fs::remove_file(&self.temp_path);
+    }
+}
+
+const EXPORT_PARTIAL_SUFFIX: &str = ".capptivo-export.partial";
+
+fn export_temp_path(final_path: &Path) -> PathBuf {
+    let mut os = final_path.as_os_str().to_os_string();
+    os.push(EXPORT_PARTIAL_SUFFIX);
+    PathBuf::from(os)
+}
+
+fn promote_temp_to_final(temp: &Path, final_path: &Path) -> AppResult<()> {
+    if final_path.exists() {
+        std::fs::remove_file(final_path)?;
+    }
+    std::fs::rename(temp, final_path).map_err(|e| {
+        let _ = std::fs::remove_file(temp);
+        AppError::Other(format!("export rename failed: {e}"))
+    })?;
+    Ok(())
+}
+
+fn drain_stderr(stderr: ChildStderr, buf: Arc<Mutex<String>>) {
+    let mut reader = std::io::BufReader::new(stderr);
+    let mut line = String::new();
+    loop {
+        line.clear();
+        match reader.read_line(&mut line) {
+            Ok(0) => break,
+            Ok(_) => {
+                let trimmed = line.trim_end_matches(['\r', '\n']);
+                if trimmed.is_empty() {
+                    continue;
+                }
+                let mut text = buf.lock().unwrap_or_else(|e| e.into_inner());
+                if !text.is_empty() {
+                    text.push('\n');
+                }
+                text.push_str(trimmed);
+                if text.len() > FFMPEG_STDERR_CAP {
+                    let drop = text.len() - FFMPEG_STDERR_CAP;
+                    text.drain(..drop);
+                }
+            }
+            Err(_) => break,
+        }
+    }
+}
+
+fn wait_child(child: &mut Child, timeout: Duration) -> AppResult<std::process::ExitStatus> {
+    let started = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return Ok(status),
+            Ok(None) if started.elapsed() >= timeout => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(AppError::Encoder(
+                    "ffmpeg h264 mux timed out during finalize".into(),
+                ));
+            }
+            Ok(None) => std::thread::sleep(Duration::from_millis(20)),
+            Err(e) => {
+                return Err(AppError::Encoder(format!(
+                    "waiting on ffmpeg h264 mux failed: {e}"
+                )));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn temp_path_is_sidecar_beside_final() {
+        let p = PathBuf::from("/tmp/out.mp4");
+        let t = export_temp_path(&p);
+        assert!(t
+            .to_string_lossy()
+            .ends_with(&format!("out.mp4{EXPORT_PARTIAL_SUFFIX}")));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ pub mod captions;
 mod capabilities;
 mod commands;
 mod proc;
+mod export_h264;
 mod webview_gpu;
 #[cfg(any(
     all(target_os = "macos", feature = "scap-capture"),
@@ -58,6 +59,7 @@ mod area_picker {
 mod backgrounds;
 mod cursor;
 mod error;
+mod error_log;
 mod media_protocol;
 mod permissions;
 mod project;
@@ -171,12 +173,20 @@ fn register_global_hotkey(app: &tauri::AppHandle) {
 }
 
 fn init_tracing() {
+    use tracing_subscriber::filter::LevelFilter;
+    use tracing_subscriber::fmt;
+    use tracing_subscriber::prelude::*;
     use tracing_subscriber::EnvFilter;
+
+    crate::error_log::init();
+
     let filter = EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| EnvFilter::new("info,desktop_lib=debug"));
-    // `try_init` so tests / repeated inits don't panic.
-    let _ = tracing_subscriber::fmt()
-        .with_env_filter(filter)
-        .with_target(false)
+    // Console keeps normal verbosity for `tauri dev`; the file layer is ERROR-only.
+    let _ = tracing_subscriber::registry()
+        .with(fmt::layer().with_target(false).with_filter(filter))
+        .with(
+            crate::error_log::ErrorFileLayer.with_filter(LevelFilter::ERROR),
+        )
         .try_init();
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,5 +1,6 @@
 //! Application state managed by Tauri and shared across commands.
 
+use crate::export_h264::H264StreamMuxer;
 use crate::project::ProjectStore;
 use crate::recorder::backend::{CaptureBackend, TestPatternBackend};
 use crate::recorder::types::{RecorderConfig, RecorderEvent};
@@ -19,6 +20,8 @@ pub struct AppState {
     pub current_project: Mutex<Option<CurrentProject>>,
     /// Open export file sinks, keyed by handle id (see `commands::export`).
     pub exports: Mutex<HashMap<u64, ExportSink>>,
+    /// Annex-B H.264 → ffmpeg MP4 sessions (see `commands::export` h264 stream).
+    pub h264_exports: Mutex<HashMap<u64, H264StreamMuxer>>,
     pub next_export_id: Mutex<u64>,
     /// Optional face-cam file being written by the camera WebView during capture.
     pub camera_sink: Mutex<Option<ExportSink>>,
@@ -73,6 +76,7 @@ impl AppState {
             store,
             current_project: Mutex::new(None),
             exports: Mutex::new(HashMap::new()),
+            h264_exports: Mutex::new(HashMap::new()),
             next_export_id: Mutex::new(1),
             camera_sink: Mutex::new(None),
             proxy_jobs: Mutex::new(HashSet::new()),

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -87,6 +87,8 @@ fn idle_menu(app: &AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
         MenuItem::with_id(app, "annotate", "Annotate Screen…", true, None::<&str>)?;
     let open_library = MenuItem::with_id(app, "open_library", "Recordings…", true, None::<&str>)?;
     let settings = MenuItem::with_id(app, "settings", "Settings…", true, None::<&str>)?;
+    let open_error_log =
+        MenuItem::with_id(app, "open_error_log", "Open Error Log…", true, None::<&str>)?;
     let check_updates =
         MenuItem::with_id(app, "check_updates", "Check for Updates…", true, None::<&str>)?;
     let separator = PredefinedMenuItem::separator(app)?;
@@ -98,6 +100,8 @@ fn idle_menu(app: &AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
             &annotate,
             &open_library,
             &settings,
+            &separator,
+            &open_error_log,
             &check_updates,
             &separator,
             &quit,
@@ -185,6 +189,11 @@ fn on_menu_event(app: &AppHandle, event: tauri::menu::MenuEvent) {
         "open_library" => {
             if let Err(e) = windows::open_library(app.clone()) {
                 tracing::warn!(%e, "failed to open recordings library");
+            }
+        }
+        "open_error_log" => {
+            if let Err(e) = crate::error_log::reveal() {
+                tracing::error!(%e, "failed to reveal error log");
             }
         }
         "settings" => {

--- a/src/ipc/bindings.ts
+++ b/src/ipc/bindings.ts
@@ -159,6 +159,17 @@ export const commands = {
         "x-export-position": String(position),
       },
     }),
+  /** Annex-B H.264 → ffmpeg `-c copy` MP4 (mux outside the WebView). */
+  beginExportH264Stream: (args: { path: string; fps: number }) =>
+    invoke<number>("begin_export_h264_stream", args),
+  writeExportH264Chunk: (handle: number, chunk: Uint8Array) =>
+    invoke<void>("write_export_h264_chunk", chunk, {
+      headers: { "x-export-handle": String(handle) },
+    }),
+  finishExportH264Stream: (handle: number) =>
+    invoke<string>("finish_export_h264_stream", { handle }),
+  abortExportH264Stream: (handle: number, reason: string) =>
+    invoke<void>("abort_export_h264_stream", { handle, reason }),
   /** Returns original dimensions and proxy filename when ready. */
   ensureProxy: (projectId: string) =>
     invoke<{ proxy: string | null; width: number; height: number }>(
@@ -208,4 +219,10 @@ export const commands = {
     invoke<void>("attach_export_audio", args),
   removeTempFile: (args: { path: string }) =>
     invoke<void>("remove_temp_file", args),
+  /** Append one error line to the on-disk error log (errors only). */
+  logClientError: (source: string, message: string) =>
+    invoke<void>("log_client_error", { source, message }),
+  /** Reveal `logs/errors.log` in Finder / Explorer. */
+  revealErrorLog: () => invoke<string>("reveal_error_log"),
+  errorLogPath: () => invoke<string>("error_log_path"),
 } as const;

--- a/src/lib/errorLogging.ts
+++ b/src/lib/errorLogging.ts
@@ -1,0 +1,52 @@
+/**
+ * Persist JS errors to the on-disk error log (Rust `logs/errors.log`).
+ * Errors only — never info/warn.
+ */
+
+import { commands } from "../ipc/bindings";
+
+function describe(e: unknown): string {
+  if (e instanceof Error) return e.message || e.name;
+  if (typeof e === "string") return e;
+  if (e && typeof e === "object") {
+    const err = e as { kind?: unknown; message?: unknown };
+    if (typeof err.message === "string" && err.message.length > 0) {
+      return err.message;
+    }
+    if (typeof err.kind === "string") return err.kind;
+    try {
+      return JSON.stringify(e);
+    } catch {
+      /* fall through */
+    }
+  }
+  return String(e);
+}
+
+let installed = false;
+
+/** Fire-and-forget append; never throws into UI. */
+export function logClientError(source: string, error: unknown): void {
+  const message = describe(error);
+  if (!message) return;
+  void commands.logClientError(source, message).catch(() => undefined);
+}
+
+/** Install once per webview: uncaught errors + rejected promises. */
+export function installErrorLogging(windowLabel: string): void {
+  if (installed || typeof window === "undefined") return;
+  installed = true;
+
+  window.addEventListener("error", (event) => {
+    const parts = [
+      event.message,
+      event.filename ? `${event.filename}:${event.lineno}:${event.colno}` : "",
+      event.error instanceof Error ? event.error.stack : "",
+    ].filter(Boolean);
+    logClientError(`${windowLabel}:uncaught`, parts.join(" | "));
+  });
+
+  window.addEventListener("unhandledrejection", (event) => {
+    logClientError(`${windowLabel}:unhandledrejection`, event.reason);
+  });
+}

--- a/src/windows/annotation/main.tsx
+++ b/src/windows/annotation/main.tsx
@@ -1,9 +1,11 @@
 import ReactDOM from "react-dom/client";
 import { SettingsProvider } from "@/lib/settings";
 import { initTheme } from "@/lib/theme";
+import { installErrorLogging } from "@/lib/errorLogging";
 import { AnnotationApp } from "./AnnotationApp";
 import "../../styles.css";
 
+installErrorLogging("annotation");
 document.documentElement.classList.add("annotation-shell");
 // Same as the editor: apply stored light/dark before paint so the bar matches
 // Capptivo's theme (tokens are already semantic — only the html class was missing).

--- a/src/windows/area/main.tsx
+++ b/src/windows/area/main.tsx
@@ -1,8 +1,10 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { installErrorLogging } from "@/lib/errorLogging";
 import { AreaPickerApp } from "./AreaPickerApp";
 import "../../styles.css";
 
+installErrorLogging("area-picker");
 document.documentElement.classList.add("area-shell");
 
 ReactDOM.createRoot(document.getElementById("root")!).render(

--- a/src/windows/camera/main.tsx
+++ b/src/windows/camera/main.tsx
@@ -1,7 +1,9 @@
 import ReactDOM from "react-dom/client";
+import { installErrorLogging } from "@/lib/errorLogging";
 import { CameraApp } from "./CameraApp";
 import "../../styles.css";
 
+installErrorLogging("camera");
 document.documentElement.classList.add("camera-shell");
 
 // No StrictMode — double-mount would stop getUserMedia and black the bubble.

--- a/src/windows/editor/export/encodeBackpressure.selfcheck.ts
+++ b/src/windows/editor/export/encodeBackpressure.selfcheck.ts
@@ -3,6 +3,7 @@
 import {
   adaptEncodeDepth,
   clampEncodeDepth,
+  encodeDepthCeiling,
   ENCODE_DEPTH_MAX,
   ENCODE_DEPTH_MIN,
   seedEncodeDepth,
@@ -16,12 +17,23 @@ assert(clampEncodeDepth(1) === ENCODE_DEPTH_MIN, "clamp floors at min");
 assert(clampEncodeDepth(99) === ENCODE_DEPTH_MAX, "clamp caps at max");
 assert(clampEncodeDepth(4.4) === 4, "clamp rounds");
 
-// 1920×1080 ≈ 2.07 MP → 48/2.07 ≈ 23.2 → 23
-assert(seedEncodeDepth(1920, 1080) === 23, "1080p seeds ~23");
-// 3840×2160 ≈ 8.3 MP → 48/8.3 ≈ 5.8 → 6
-assert(seedEncodeDepth(3840, 2160) === 6, "4K seeds ~6");
-// Tiny output hits max
-assert(seedEncodeDepth(640, 360) === ENCODE_DEPTH_MAX, "small output seeds max");
+assert(encodeDepthCeiling(30) === 23, "30fps ceiling ~0.75s → 23");
+assert(encodeDepthCeiling(60) === 45, "60fps ceiling ~0.75s → 45");
+
+// 1920×1080 ≈ 2.07 MP → 48/2.07 ≈ 23 at 30fps
+assert(seedEncodeDepth(1920, 1080, 30) === 23, "1080p30 seeds ~23");
+// Same pixels at 60fps → half via fps scale (23 * 30/60 ≈ 11.5 → 12)
+assert(seedEncodeDepth(1920, 1080, 60) === 12, "1080p60 seeds ~12");
+assert(
+  seedEncodeDepth(1920, 1080, 60) < seedEncodeDepth(1920, 1080, 30),
+  "60fps seed must be below 30fps seed",
+);
+// 3840×2160 ≈ 8.3 MP → 48/8.3 ≈ 5.8 → 6 at 30fps; ~3 at 60fps
+assert(seedEncodeDepth(3840, 2160, 30) === 6, "4K30 seeds ~6");
+assert(seedEncodeDepth(3840, 2160, 60) === 3, "4K60 seeds ~3");
+// Tiny output at 30fps hits ceiling (~23), not global max
+assert(seedEncodeDepth(640, 360, 30) === 23, "small@30 hits fps ceiling");
+assert(seedEncodeDepth(640, 360, 60) === 45, "small@60 hits 0.75s ceiling");
 
 const budget = 1000 / 30; // ~33.3 ms
 
@@ -53,6 +65,28 @@ assert(
     frameBudgetMs: budget,
   }) === 5,
   "light composite + idle encode → deepen",
+);
+
+assert(
+  adaptEncodeDepth({
+    depth: 11,
+    emaCompositeMs: 5,
+    emaEncodeWaitMs: 0,
+    frameBudgetMs: budget,
+    maxDepth: 12,
+  }) === 12,
+  "deepen respects fps maxDepth",
+);
+
+assert(
+  adaptEncodeDepth({
+    depth: 12,
+    emaCompositeMs: 5,
+    emaEncodeWaitMs: 0,
+    frameBudgetMs: budget,
+    maxDepth: 12,
+  }) === 12,
+  "never above session maxDepth",
 );
 
 assert(

--- a/src/windows/editor/export/encodeBackpressure.ts
+++ b/src/windows/editor/export/encodeBackpressure.ts
@@ -6,12 +6,10 @@
  * of those in-flight encodes we allow before awaiting the oldest — that is the
  * backpressure valve (memory + error latency).
  *
- * Seed depth from output megapixels (more pixels → fewer concurrent frames).
- * Then nudge ±1 every few frames from EMA of composite cost vs encode wait,
- * relative to the output frame budget (`1000/fps`).
+ * Seed from output megapixels, then tighten for high fps so 60fps does not keep
+ * the same in-flight count as 30fps (half the frame budget → less GPU pressure).
+ * Adapt ±1 from composite vs encode wait EMAs, never above the fps ceiling.
  *
- * Ceiling matches a stable consumer-GPU encode queue (~48); the megapixel
- * soft-cap keeps 4K from opening that many full frames at once.
  * Backpressure awaits promises — never `requestAnimationFrame` (rAF stalls when
  * the window is backgrounded and can starve the encoder).
  */
@@ -21,22 +19,46 @@ export const ENCODE_DEPTH_MAX = 48;
 
 /** Soft cap on in-flight uncompressed frame area (~48 MP total → ~23 at 1080p). */
 const TARGET_IN_FLIGHT_MP = 48;
+/** Reference fps for depth scaling — above this, shrink in-flight count. */
+const REF_FPS = 30;
+/** Wall-clock backlog ceiling (~0.75s of frames). */
+const QUEUE_SECONDS = 0.75;
 
 const EMA_ALPHA = 0.2;
 /** How often depth may change — avoids thrashing every frame. */
 const ADAPT_EVERY = 8;
 
-export function clampEncodeDepth(n: number): number {
-  return Math.max(ENCODE_DEPTH_MIN, Math.min(ENCODE_DEPTH_MAX, Math.round(n)));
+export function clampEncodeDepth(
+  n: number,
+  max: number = ENCODE_DEPTH_MAX,
+): number {
+  const hi = Math.max(ENCODE_DEPTH_MIN, Math.min(ENCODE_DEPTH_MAX, max));
+  return Math.max(ENCODE_DEPTH_MIN, Math.min(hi, Math.round(n)));
 }
 
 /**
- * Initial queue depth from output resolution. 1080p (~2.1 MP) → ~23;
- * 4K (~8.3 MP) → ~6; small outputs hit the max.
+ * Hard ceiling from fps: ~0.75s of frames, never above {@link ENCODE_DEPTH_MAX}.
+ * 30fps → ~23; 60fps → ~45 (then megapixel / scale caps usually win first).
  */
-export function seedEncodeDepth(width: number, height: number): number {
+export function encodeDepthCeiling(fps: number): number {
+  return clampEncodeDepth(Math.max(1, fps) * QUEUE_SECONDS);
+}
+
+/**
+ * Initial queue depth. 1080p30 → ~23; 1080p60 → ~12 (fps scale);
+ * 4K → lower from megapixels.
+ */
+export function seedEncodeDepth(
+  width: number,
+  height: number,
+  fps: number = REF_FPS,
+): number {
   const mp = Math.max(1e-6, (width * height) / 1_000_000);
-  return clampEncodeDepth(TARGET_IN_FLIGHT_MP / mp);
+  const byPixels = TARGET_IN_FLIGHT_MP / mp;
+  const ceiling = encodeDepthCeiling(fps);
+  // Same resolution at 60fps → half the in-flight frames of 30fps.
+  const byFpsScale = byPixels * (REF_FPS / Math.max(fps, REF_FPS));
+  return clampEncodeDepth(Math.min(byPixels, byFpsScale, ceiling), ceiling);
 }
 
 export type AdaptEncodeDepthInput = {
@@ -44,6 +66,8 @@ export type AdaptEncodeDepthInput = {
   emaCompositeMs: number;
   emaEncodeWaitMs: number;
   frameBudgetMs: number;
+  /** Session max (fps ceiling); defaults to {@link ENCODE_DEPTH_MAX}. */
+  maxDepth?: number;
 };
 
 /**
@@ -54,8 +78,15 @@ export type AdaptEncodeDepthInput = {
  * - Composite light and encode wait ~0 → deepen (hide encode latency).
  */
 export function adaptEncodeDepth(input: AdaptEncodeDepthInput): number {
-  const { depth, emaCompositeMs, emaEncodeWaitMs, frameBudgetMs } = input;
+  const {
+    depth,
+    emaCompositeMs,
+    emaEncodeWaitMs,
+    frameBudgetMs,
+    maxDepth = ENCODE_DEPTH_MAX,
+  } = input;
   const budget = Math.max(1e-3, frameBudgetMs);
+  const max = Math.max(ENCODE_DEPTH_MIN, Math.min(ENCODE_DEPTH_MAX, maxDepth));
 
   if (emaEncodeWaitMs > budget * 0.75) {
     return Math.max(ENCODE_DEPTH_MIN, depth - 1);
@@ -64,9 +95,9 @@ export function adaptEncodeDepth(input: AdaptEncodeDepthInput): number {
     return Math.max(ENCODE_DEPTH_MIN, depth - 1);
   }
   if (emaCompositeMs < budget * 0.4 && emaEncodeWaitMs < 1) {
-    return Math.min(ENCODE_DEPTH_MAX, depth + 1);
+    return Math.min(max, depth + 1);
   }
-  return depth;
+  return Math.min(max, depth);
 }
 
 function ema(prev: number, sample: number, framesBefore: number): number {
@@ -80,6 +111,7 @@ function ema(prev: number, sample: number, framesBefore: number): number {
  */
 export class AdaptiveEncodeQueue {
   depth: number;
+  private readonly maxDepth: number;
   private readonly frameBudgetMs: number;
   private readonly pending: Promise<void>[] = [];
   private emaCompositeMs = 0;
@@ -88,13 +120,15 @@ export class AdaptiveEncodeQueue {
   private encodeWaits = 0;
 
   constructor(width: number, height: number, fps: number) {
-    this.depth = seedEncodeDepth(width, height);
+    this.maxDepth = encodeDepthCeiling(fps);
+    this.depth = seedEncodeDepth(width, height, fps);
     this.frameBudgetMs = 1000 / Math.max(1, fps);
   }
 
   /** Snapshot for logging / diagnostics. */
   stats(): {
     depth: number;
+    maxDepth: number;
     pending: number;
     frames: number;
     emaCompositeMs: number;
@@ -103,6 +137,7 @@ export class AdaptiveEncodeQueue {
   } {
     return {
       depth: this.depth,
+      maxDepth: this.maxDepth,
       pending: this.pending.length,
       frames: this.frames,
       emaCompositeMs: this.emaCompositeMs,
@@ -137,6 +172,7 @@ export class AdaptiveEncodeQueue {
         emaCompositeMs: this.emaCompositeMs,
         emaEncodeWaitMs: this.emaEncodeWaitMs,
         frameBudgetMs: this.frameBudgetMs,
+        maxDepth: this.maxDepth,
       });
     }
   }

--- a/src/windows/editor/export/exportH264Ffmpeg.ts
+++ b/src/windows/editor/export/exportH264Ffmpeg.ts
@@ -1,0 +1,381 @@
+/**
+ * MP4 export via WebCodecs Annex-B H.264 → Rust ffmpeg `-c copy` mux.
+ *
+ * Pixi compose and HW encode stay in the WebView; container mux/IO run in the
+ * ffmpeg sidecar so WebView2 is not also writing the MP4 (the Windows failure
+ * mode when mediabunny muxes in-process).
+ */
+
+import { commands } from "../../../ipc/bindings";
+import { faceCamMediaTime, type FaceCamTrack } from "../lib/faceCamSync";
+import {
+  createExportCompositor,
+  createExportCompositorFromMedia,
+  planFrameTimes,
+  seekTo,
+} from "./exportCompositor";
+import { openSequentialMedia } from "./sequentialMedia";
+import { shouldYieldNow, yieldToMain } from "./exportYield";
+import {
+  adaptEncodeDepth,
+  encodeDepthCeiling,
+  seedEncodeDepth,
+} from "./encodeBackpressure";
+import { throwIfAborted } from "./exportCancel";
+import type { ResolvedExportParams } from "./exportSettings";
+import { GpuContextLostError } from "../render/gpuLifecycle";
+import { useEditorStore } from "../store";
+import { describeError } from "../../recorder/store";
+import {
+  ANNEX_B_CODEC,
+  isAnnexBStartCode,
+  isH264Keyframe,
+} from "./h264Keyframe";
+
+export {
+  ANNEX_B_CODEC,
+  H264_KEYFRAME_INTERVAL_SEC,
+  isAnnexBStartCode,
+  isH264Keyframe,
+} from "./h264Keyframe";
+
+/** Cap in-flight IPC writes so encode does not outrun the ffmpeg pipe. */
+const MAX_PENDING_WRITES = 6;
+
+/** Try High@L4.2 first (1080p60), then L4.0. */
+const ANNEX_B_CODEC_CANDIDATES = [ANNEX_B_CODEC, "avc1.640028"] as const;
+
+type HwMode = NonNullable<VideoEncoderConfig["hardwareAcceleration"]>;
+type LatencyMode = NonNullable<VideoEncoderConfig["latencyMode"]>;
+
+export type AnnexBEncodeTuning = {
+  codec: string;
+  hardwareAcceleration: HwMode;
+  latencyMode: LatencyMode;
+};
+
+function throwIfGpuLost(isLost: () => boolean): void {
+  if (isLost()) throw new GpuContextLostError();
+}
+
+export async function probeAnnexBConfig(
+  width: number,
+  height: number,
+  bitrate: number,
+  fps: number,
+): Promise<AnnexBEncodeTuning | null> {
+  if (typeof VideoEncoder === "undefined" || !VideoEncoder.isConfigSupported) {
+    return null;
+  }
+  // WebCodecs H.264 requires even dimensions.
+  if (width % 2 !== 0 || height % 2 !== 0) return null;
+
+  const hardwareModes: HwMode[] = [
+    "prefer-hardware",
+    "no-preference",
+    "prefer-software",
+  ];
+  const latencyModes: LatencyMode[] = ["realtime", "quality"];
+
+  for (const codec of ANNEX_B_CODEC_CANDIDATES) {
+    for (const hardwareAcceleration of hardwareModes) {
+      for (const latencyMode of latencyModes) {
+        const config: VideoEncoderConfig = {
+          codec,
+          width,
+          height,
+          bitrate,
+          framerate: fps,
+          hardwareAcceleration,
+          latencyMode,
+          avc: { format: "annexb" },
+        };
+        try {
+          const { supported } = await VideoEncoder.isConfigSupported(config);
+          if (supported) {
+            return { codec, hardwareAcceleration, latencyMode };
+          }
+        } catch {
+          // try next combo
+        }
+      }
+    }
+  }
+  return null;
+}
+
+/** True when this machine can run the ffmpeg Annex-B mux path for MP4. */
+export async function canExportMp4ViaFfmpegH264(
+  width: number,
+  height: number,
+  bitrate: number,
+  fps: number,
+): Promise<boolean> {
+  return (await probeAnnexBConfig(width, height, bitrate, fps)) != null;
+}
+
+/**
+ * Compose + WebCodecs Annex-B encode → ffmpeg stream-copy MP4 at `path`.
+ * Audio is attached afterward by the caller (same as video-only + post-mux).
+ */
+export async function renderMp4ViaFfmpegH264(
+  path: string,
+  screenUrl: string,
+  faceCam: FaceCamTrack,
+  params: ResolvedExportParams,
+  signal: AbortSignal,
+  tuning?: AnnexBEncodeTuning,
+): Promise<void> {
+  const { width, height, fps, bitrate } = params;
+  throwIfAborted(signal);
+
+  const resolvedTuning =
+    tuning ?? (await probeAnnexBConfig(width, height, bitrate, fps));
+  if (!resolvedTuning) {
+    throw new Error("Annex-B H.264 encode is unavailable for ffmpeg mux");
+  }
+
+  const handle = await commands.beginExportH264Stream({ path, fps });
+  let settled = false;
+  const abortMux = async (reason: string) => {
+    if (settled) return;
+    settled = true;
+    await commands.abortExportH264Stream(handle, reason).catch(() => undefined);
+  };
+
+  const sequential = await openSequentialMedia(screenUrl, faceCam).catch(
+    () => null,
+  );
+  const session = sequential
+    ? await createExportCompositorFromMedia(sequential.media, width, height)
+    : await createExportCompositor(screenUrl, faceCam, width, height);
+  const {
+    canvas,
+    video,
+    camera,
+    segments,
+    drawAt,
+    dispose,
+    backend,
+    stats,
+    uploadStats,
+    isGpuLost,
+  } = session;
+
+  let writeChain: Promise<void> = Promise.resolve();
+  let writeError: Error | null = null;
+  let pendingWrites = 0;
+  let framesEncoded = 0;
+  let checkedAnnexB = false;
+
+  const fail = (e: unknown) => {
+    if (!writeError) writeError = new Error(describeError(e));
+  };
+
+  const enqueueChunk = (chunk: EncodedVideoChunk) => {
+    const buf = new Uint8Array(chunk.byteLength);
+    chunk.copyTo(buf);
+    if (!checkedAnnexB) {
+      checkedAnnexB = true;
+      if (!isAnnexBStartCode(buf)) {
+        fail(
+          "WebCodecs did not emit Annex-B H.264 (no start code) — cannot mux with ffmpeg",
+        );
+        return;
+      }
+    }
+    pendingWrites += 1;
+    writeChain = writeChain
+      .then(async () => {
+        if (writeError || signal.aborted) return;
+        await commands.writeExportH264Chunk(handle, buf);
+      })
+      .catch(fail)
+      .finally(() => {
+        pendingWrites = Math.max(0, pendingWrites - 1);
+      });
+  };
+
+  const encoder = new VideoEncoder({
+    output: (chunk) => enqueueChunk(chunk),
+    error: fail,
+  });
+
+  let encodeDepth = seedEncodeDepth(width, height, fps);
+  const maxEncodeDepth = encodeDepthCeiling(fps);
+  const frameBudgetMs = 1000 / Math.max(1, fps);
+  let emaCompositeMs = 0;
+  let emaEncodeWaitMs = 0;
+  let adaptFrames = 0;
+
+  const ema = (prev: number, sample: number, n: number) =>
+    n === 0 ? sample : 0.2 * sample + 0.8 * prev;
+
+  try {
+    encoder.configure({
+      codec: resolvedTuning.codec,
+      width,
+      height,
+      bitrate,
+      framerate: fps,
+      bitrateMode: "variable",
+      latencyMode: resolvedTuning.latencyMode,
+      hardwareAcceleration: resolvedTuning.hardwareAcceleration,
+      avc: { format: "annexb" },
+    });
+
+    const frameDurationUs = Math.round(1_000_000 / Math.max(1, fps));
+    const frameTimes = planFrameTimes(segments, fps);
+    const reader =
+      sequential?.begin(frameTimes, { mode: "video-frame" }) ?? null;
+    const progress = throttledProgress(frameTimes.length);
+
+    console.info(
+      `[export] ffmpeg-h264: path=${reader ? "sequential" : "seek"} ` +
+        `compositor=${backend} frames=${frameTimes.length} ` +
+        `hw=${resolvedTuning.hardwareAcceleration} latency=${resolvedTuning.latencyMode} ` +
+        `encodeDepthSeed=${encodeDepth}`,
+    );
+
+    let timestampUs = 0;
+    let lastYieldAt = performance.now();
+    let driftLogs = 0;
+    let yields = 0;
+    let yieldMs = 0;
+    const loopStart = performance.now();
+
+    for (const t of frameTimes) {
+      throwIfAborted(signal);
+      if (writeError) throw writeError;
+      throwIfGpuLost(isGpuLost);
+
+      if (reader) {
+        await reader.nextFrame();
+      } else {
+        await seekTo(video, t);
+        if (camera) {
+          const camT = faceCamMediaTime(t, faceCam.offsetMs, camera.duration);
+          if (camT != null) await seekTo(camera, camT).catch(() => undefined);
+        }
+        if (Math.abs(video.currentTime - t) > 0.1 && driftLogs < 10) {
+          driftLogs += 1;
+          console.warn(
+            `[export] ffmpeg-h264 seek clamp: wanted ${t.toFixed(3)}s ` +
+              `got ${video.currentTime.toFixed(3)}s`,
+          );
+        }
+      }
+
+      throwIfGpuLost(isGpuLost);
+      const composeStart = performance.now();
+      drawAt(t);
+      throwIfGpuLost(isGpuLost);
+      const composeMs = performance.now() - composeStart;
+      emaCompositeMs = ema(emaCompositeMs, composeMs, adaptFrames);
+
+      // Backpressure: encoder queue + IPC write pipeline.
+      const waitStart = performance.now();
+      while (
+        encoder.encodeQueueSize >= encodeDepth ||
+        pendingWrites >= MAX_PENDING_WRITES
+      ) {
+        await writeChain.catch(() => undefined);
+        if (writeError) throw writeError;
+        throwIfAborted(signal);
+        if (encoder.encodeQueueSize >= encodeDepth) {
+          await yieldToMain();
+        }
+      }
+      const waitMs = performance.now() - waitStart;
+      if (waitMs > 0) {
+        emaEncodeWaitMs = ema(emaEncodeWaitMs, waitMs, adaptFrames);
+      }
+
+      const frame = new VideoFrame(canvas as CanvasImageSource, {
+        timestamp: timestampUs,
+        duration: frameDurationUs,
+      });
+      try {
+        encoder.encode(frame, {
+          keyFrame: isH264Keyframe(framesEncoded, fps),
+        });
+        framesEncoded += 1;
+      } finally {
+        frame.close();
+      }
+
+      adaptFrames += 1;
+      if (adaptFrames % 8 === 0) {
+        encodeDepth = adaptEncodeDepth({
+          depth: encodeDepth,
+          emaCompositeMs,
+          emaEncodeWaitMs,
+          frameBudgetMs,
+          maxDepth: maxEncodeDepth,
+        });
+      }
+
+      progress(framesEncoded);
+      timestampUs += frameDurationUs;
+
+      const decision = shouldYieldNow(performance.now(), lastYieldAt);
+      if (decision.shouldYield) {
+        yields += 1;
+        const yieldStart = performance.now();
+        await yieldToMain();
+        lastYieldAt = performance.now();
+        yieldMs += lastYieldAt - yieldStart;
+        throwIfAborted(signal);
+      }
+    }
+
+    await encoder.flush();
+    await writeChain;
+    if (writeError) throw writeError;
+    if (framesEncoded === 0) {
+      throw new Error("ffmpeg h264 export produced no frames");
+    }
+
+    const wallMs = performance.now() - loopStart;
+    const uploads = uploadStats();
+    console.info(
+      `[export] ffmpeg-h264 done in ${(wallMs / 1000).toFixed(1)}s ` +
+        `(${(framesEncoded / (wallMs / 1000)).toFixed(1)} fps) — ` +
+        `depth=${encodeDepth} yields=${yields} yieldMs=${yieldMs.toFixed(0)}` +
+        (uploads
+          ? ` uploads=${uploads.uploads} skipped=${uploads.skipped}`
+          : ""),
+    );
+    const breakdown = stats();
+    if (breakdown) console.info(`[export] composite breakdown: ${breakdown}`);
+
+    settled = true;
+    await commands.finishExportH264Stream(handle);
+  } catch (e) {
+    const reason = describeError(e);
+    console.error(`[export] ffmpeg-h264 failed: ${reason}`);
+    await abortMux(reason);
+    throw e instanceof Error ? e : new Error(reason);
+  } finally {
+    try {
+      if (encoder.state !== "closed") encoder.close();
+    } catch {
+      /* ignore */
+    }
+    dispose();
+    if (!settled) {
+      await abortMux("export failed");
+    }
+  }
+}
+
+function throttledProgress(total: number): (done: number) => void {
+  let lastPercent = -1;
+  return (done: number) => {
+    const ratio = Math.min(1, done / Math.max(1, total));
+    const percent = Math.round(ratio * 100);
+    if (percent === lastPercent) return;
+    lastPercent = percent;
+    useEditorStore.getState().setExportProgress(ratio);
+  };
+}

--- a/src/windows/editor/export/exportSettings.selfcheck.ts
+++ b/src/windows/editor/export/exportSettings.selfcheck.ts
@@ -3,7 +3,8 @@
 // ponytail: mirrors helpers in exportSettings.ts — keeps this file
 // dependency-free for Node selfcheck (exportSettings pulls composition).
 const BALANCED = 8_000_000;
-const REF_PIXEL_RATE = 1920 * 1080 * 30;
+const REF_PIXELS = 1920 * 1080;
+const REF_FPS = 30;
 const MIN = 500_000;
 const MAX = 50_000_000;
 
@@ -13,7 +14,9 @@ const GIF_SPEED_STEP = 0.25;
 const DEFAULT_GIF_SPEED = 1;
 
 function scaled(encodingBitrate: number, w: number, h: number, fps: number): number {
-  const raw = Math.round(encodingBitrate * ((w * h * fps) / REF_PIXEL_RATE));
+  const pixelScale = (w * h) / REF_PIXELS;
+  const fpsScale = Math.sqrt(Math.max(1, fps / REF_FPS));
+  const raw = Math.round(encodingBitrate * pixelScale * fpsScale);
   return Math.max(MIN, Math.min(MAX, raw));
 }
 
@@ -31,6 +34,7 @@ function assert(cond: boolean, msg: string): void {
 
 const hd60 = scaled(BALANCED, 1920, 1080, 60);
 const hd30 = scaled(BALANCED, 1920, 1080, 30);
+const hd24 = scaled(BALANCED, 1920, 1080, 24);
 const sd24 = scaled(BALANCED, 640, 360, 24);
 
 assert(hd60 > sd24, `1080p60 (${hd60}) should exceed 640×360@24 (${sd24})`);
@@ -38,6 +42,14 @@ assert(
   Math.abs(hd30 - BALANCED) < 500_000,
   `1080p30 balanced should be ~8 Mbps, got ${hd30}`,
 );
+assert(hd24 === hd30, `24fps should not under-scale vs 30fps (got ${hd24} vs ${hd30})`);
+
+const expected60 = Math.round(BALANCED * Math.sqrt(2));
+assert(
+  Math.abs(hd60 - expected60) < 1,
+  `1080p60 should be ~√2× 30fps (${expected60}), got ${hd60}`,
+);
+assert(hd60 < BALANCED * 2, `60fps must not fully double 30fps bitrate (got ${hd60})`);
 
 assert(clampGifSpeed(undefined) === DEFAULT_GIF_SPEED, "missing → default");
 assert(clampGifSpeed(0) === GIF_SPEED_MIN, "below min clamps");

--- a/src/windows/editor/export/exportSettings.ts
+++ b/src/windows/editor/export/exportSettings.ts
@@ -98,11 +98,17 @@ const ENCODING_BITRATE: Record<ExportEncoding, number> = {
   quality: 16_000_000,
 };
 
-/** Reference pixel rate for "balanced" tiers (1080p @ 30 fps). */
-const REF_PIXEL_RATE = 1920 * 1080 * 30;
+/** Reference pixels / fps for bitrate scaling (1080p @ 30). */
+const REF_PIXELS = 1920 * 1080;
+const REF_FPS = 30;
 const MIN_VIDEO_BITRATE = 500_000;
 const MAX_VIDEO_BITRATE = 50_000_000;
 
+/**
+ * Bitrate grows with resolution linearly, but only with √(fps/30) for frame
+ * rate — so 60fps is ~1.4× 30fps, not 2× (linear fps was overworking the
+ * encoder on Windows WebView2 at 60).
+ */
 function scaledVideoBitrate(
   encoding: ExportEncoding,
   width: number,
@@ -110,12 +116,11 @@ function scaledVideoBitrate(
   fps: number,
 ): number {
   const base = ENCODING_BITRATE[encoding];
-  const scale = (width * height * fps) / REF_PIXEL_RATE;
-  const raw = Math.round(base * scale);
-  return Math.max(
-    MIN_VIDEO_BITRATE,
-    Math.min(MAX_VIDEO_BITRATE, raw),
-  );
+  const pixelScale = (width * height) / REF_PIXELS;
+  // Floor at 1 so 24fps does not under-scale below the 30fps reference.
+  const fpsScale = Math.sqrt(Math.max(1, fps / REF_FPS));
+  const raw = Math.round(base * pixelScale * fpsScale);
+  return Math.max(MIN_VIDEO_BITRATE, Math.min(MAX_VIDEO_BITRATE, raw));
 }
 
 /** Encoder output dims for the given stage: format long-edge cap + 16px align. */

--- a/src/windows/editor/export/exportVideo.ts
+++ b/src/windows/editor/export/exportVideo.ts
@@ -1,8 +1,9 @@
 /**
- * Export: composite the timeline to MP4/WebM (MediaRecorder) or GIF (gifenc).
+ * Export: composite the timeline to MP4/WebM/GIF.
  *
+ * MP4 prefers Pixi compose → WebCodecs Annex-B H.264 → Rust ffmpeg `-c copy`.
+ * WebM (and Annex-B-unavailable) use mediabunny in-webview mux; GIF uses gifenc.
  * Export media is loaded as blob: URLs so the canvas is not tainted by media://.
- * That lets GIF read pixels; MP4 still uses captureStream + MediaRecorder.
  */
 
 import { save } from "@tauri-apps/plugin-dialog";
@@ -29,6 +30,7 @@ import { totalKeptDuration } from "@/engine";
 import { mediaUrl } from "@/lib/platform";
 import { commands } from "../../../ipc/bindings";
 import { describeError } from "../../recorder/store";
+import { logClientError } from "@/lib/errorLogging";
 import { useEditorStore } from "../store";
 import {
   createExportCompositor,
@@ -43,6 +45,10 @@ import { AdaptiveEncodeQueue } from "./encodeBackpressure";
 import { ExportSink } from "./exportSink";
 import { openExportAudioTrack } from "./exportAudioTrack";
 import { renderGifToSink } from "./exportGif";
+import {
+  probeAnnexBConfig,
+  renderMp4ViaFfmpegH264,
+} from "./exportH264Ffmpeg";
 import {
   beginExportAbort,
   endExportAbort,
@@ -167,6 +173,7 @@ export async function exportProject(
     path = await pickSavePath(suggestedName, fileExt);
   } catch (e) {
     store.setExportError(describeError(e));
+    logClientError("export:pickPath", e);
   }
   if (!path || signal.aborted) {
     endExportAbort();
@@ -188,6 +195,7 @@ export async function exportProject(
   } catch (e) {
     endExportAbort();
     store.setExportError(describeError(e));
+    logClientError("export:diskSpace", e);
     store.setExporting(false);
     store.setExportStatus(null);
     return;
@@ -252,54 +260,109 @@ export async function exportProject(
         exportPath = alignExportPathExtension(path, fileExt);
       }
     }
-    sink = await ExportSink.open(exportPath);
     throwIfAborted(signal);
 
     if (resolved.format === "gif") {
+      sink = await ExportSink.open(exportPath);
       await renderGifToSink(sink, screenUrl, faceCam, resolved, signal);
-    } else {
-      const prepared = audioPrep ? await audioPrep : null;
-      throwIfAborted(signal);
-      audioAbsPath = prepared?.absPath ?? null;
-      const audioMuxed = await renderVideoToSink(
-        sink,
-        screenUrl,
-        faceCam,
-        resolved,
-        prepared?.mediaUrl ?? null,
-        signal,
-      );
-      throwIfAborted(signal);
       store.setExportStatus(translateNow("export.status.saving"));
       const saved = await sink.finish();
       sink = null;
+      await notifyDone(saved);
+      return;
+    }
 
-      // In-container mux succeeded → skip the rewrite. Otherwise fall back to
-      // FFmpeg attach (or the classic one-shot mux if prepare also failed).
-      if (!audioMuxed) {
+    const prepared = audioPrep ? await audioPrep : null;
+    throwIfAborted(signal);
+    audioAbsPath = prepared?.absPath ?? null;
+
+    // Prefer out-of-webview ffmpeg mux for MP4: WebCodecs emits Annex-B,
+    // Rust only stream-copies into the container (no re-encode).
+    const annexBTuning =
+      resolved.container === "mp4"
+        ? await probeAnnexBConfig(
+            resolved.width,
+            resolved.height,
+            resolved.bitrate,
+            resolved.fps,
+          )
+        : null;
+
+    if (annexBTuning) {
+      console.info("[export] path=ffmpeg-h264-stream (mux outside WebView)");
+      try {
+        await renderMp4ViaFfmpegH264(
+          exportPath,
+          screenUrl,
+          faceCam,
+          resolved,
+          signal,
+          annexBTuning,
+        );
+        throwIfAborted(signal);
+        store.setExportStatus(translateNow("export.status.saving"));
         if (prepared) {
           store.setExportStatus(translateNow("export.status.addingAudio"));
           await commands
             .attachExportAudio({
-              videoPath: saved,
+              videoPath: exportPath,
               audioPath: prepared.absPath,
             })
             .catch(async (e) => {
               console.warn("export audio attach failed; trying full mux", e);
-              await muxRecordedAudio(saved, settings.audioEnhance);
+              await muxRecordedAudio(exportPath, settings.audioEnhance);
             });
         } else {
-          await muxRecordedAudio(saved, settings.audioEnhance).catch((e) =>
+          await muxRecordedAudio(exportPath, settings.audioEnhance).catch((e) =>
             console.warn("export audio mux failed; keeping silent video", e),
           );
         }
+        await notifyDone(exportPath);
+        return;
+      } catch (e) {
+        if (isExportCancelled(e) || isGpuContextLostError(e)) throw e;
+        console.warn(
+          `[export] ffmpeg-h264 failed (${describeError(e)}); falling back to in-webview mux`,
+        );
+        logClientError("export:ffmpeg-h264", e);
       }
-
-      await notifyDone(saved);
-      return;
     }
+
+    sink = await ExportSink.open(exportPath);
+    const audioMuxed = await renderVideoToSink(
+      sink,
+      screenUrl,
+      faceCam,
+      resolved,
+      prepared?.mediaUrl ?? null,
+      signal,
+    );
+    throwIfAborted(signal);
     store.setExportStatus(translateNow("export.status.saving"));
     const saved = await sink.finish();
+    sink = null;
+
+    // In-container mux succeeded → skip the rewrite. Otherwise fall back to
+    // FFmpeg attach (or the classic one-shot mux if prepare also failed).
+    if (!audioMuxed) {
+      if (prepared) {
+        store.setExportStatus(translateNow("export.status.addingAudio"));
+        await commands
+          .attachExportAudio({
+            videoPath: saved,
+            audioPath: prepared.absPath,
+          })
+          .catch(async (e) => {
+            console.warn("export audio attach failed; trying full mux", e);
+            await muxRecordedAudio(saved, settings.audioEnhance);
+          });
+      } else {
+        await muxRecordedAudio(saved, settings.audioEnhance).catch((e) =>
+          console.warn("export audio mux failed; keeping silent video", e),
+        );
+      }
+    }
+
     await notifyDone(saved);
   } catch (e) {
     await sink?.abort(e);
@@ -311,8 +374,10 @@ export async function exportProject(
         useEditorStore
           .getState()
           .setExportError(translateNow("export.error.gpuContextLost"));
+        logClientError("export:gpu", e);
       } else {
         useEditorStore.getState().setExportError(describeError(e));
+        logClientError("export", e);
       }
     }
   } finally {
@@ -500,8 +565,8 @@ async function pickVideoEncodeTuning(
  * MediaRecorder if the browser can't encode via WebCodecs at all.
  *
  * Encode queue depth is adaptive (`AdaptiveEncodeQueue`): seeded by output
- * megapixels, then nudged from composite vs encode timing so the encoder stays
- * fed without unbounded in-flight frames.
+ * megapixels and tightened at high fps, then nudged from composite vs encode
+ * timing so the encoder stays fed without unbounded in-flight frames.
  */
 async function renderVideoToSink(
   sink: ExportSink,

--- a/src/windows/editor/export/h264Keyframe.selfcheck.ts
+++ b/src/windows/editor/export/h264Keyframe.selfcheck.ts
@@ -1,0 +1,39 @@
+/** Selfcheck: H.264 keyframe helpers (pure). */
+
+import {
+  ANNEX_B_CODEC,
+  H264_KEYFRAME_INTERVAL_SEC,
+  isAnnexBStartCode,
+  isH264Keyframe,
+} from "./h264Keyframe.ts";
+
+function assert(cond: boolean, msg: string): void {
+  if (!cond) throw new Error(msg);
+}
+
+assert(ANNEX_B_CODEC.startsWith("avc1."), "annex-b codec is avc1");
+assert(H264_KEYFRAME_INTERVAL_SEC === 4, "keyframe interval is 4s");
+
+assert(isH264Keyframe(0, 30), "frame 0 is always a keyframe");
+assert(isH264Keyframe(120, 30), "30fps → keyframe every 120 frames");
+assert(!isH264Keyframe(1, 30), "frame 1 is not a keyframe at 30fps");
+assert(!isH264Keyframe(119, 30), "frame 119 is not a keyframe at 30fps");
+assert(isH264Keyframe(240, 60), "60fps → keyframe every 240 frames");
+assert(!isH264Keyframe(239, 60), "frame 239 is not a keyframe at 60fps");
+assert(isH264Keyframe(0, 1), "1fps still keyframes frame 0");
+assert(isH264Keyframe(4, 1), "1fps keyframes every 4 frames");
+
+assert(
+  isAnnexBStartCode(new Uint8Array([0, 0, 0, 1, 0x65])),
+  "4-byte start code is annex-b",
+);
+assert(
+  isAnnexBStartCode(new Uint8Array([0, 0, 1, 0x65])),
+  "3-byte start code is annex-b",
+);
+assert(
+  !isAnnexBStartCode(new Uint8Array([0, 0, 0, 0x50, 0x65])),
+  "length-prefixed avcC is not annex-b",
+);
+
+console.log("h264Keyframe.selfcheck: ok");

--- a/src/windows/editor/export/h264Keyframe.ts
+++ b/src/windows/editor/export/h264Keyframe.ts
@@ -1,0 +1,24 @@
+/** Pure H.264 export helpers (safe for Node selfchecks). */
+
+/** High@L4.2 — covers 1080p60; Annex-B for ffmpeg `-f h264`. */
+export const ANNEX_B_CODEC = "avc1.64002A";
+
+/** I-frame every N seconds — fewer keyframes → less encoder work. */
+export const H264_KEYFRAME_INTERVAL_SEC = 4;
+
+export function isH264Keyframe(
+  frameIndex: number,
+  fps: number,
+  intervalSec = H264_KEYFRAME_INTERVAL_SEC,
+): boolean {
+  const every = Math.max(1, Math.round(fps * intervalSec));
+  return frameIndex % every === 0;
+}
+
+/** True when `data` starts with an Annex-B start code (3- or 4-byte). */
+export function isAnnexBStartCode(data: Uint8Array): boolean {
+  if (data.length >= 4 && data[0] === 0 && data[1] === 0 && data[2] === 0 && data[3] === 1) {
+    return true;
+  }
+  return data.length >= 3 && data[0] === 0 && data[1] === 0 && data[2] === 1;
+}

--- a/src/windows/editor/main.tsx
+++ b/src/windows/editor/main.tsx
@@ -4,9 +4,11 @@ import { setCursorDebugOverlay } from "@/engine";
 import { AppToaster } from "@/lib/toast";
 import { SettingsProvider } from "@/lib/settings";
 import { initTheme } from "@/lib/theme";
+import { installErrorLogging } from "@/lib/errorLogging";
 import { EditorApp } from "./EditorApp";
 import "../../styles.css";
 
+installErrorLogging("editor");
 document.documentElement.classList.add("editor-shell");
 // Apply the stored theme to <html> before first paint to avoid a theme flash.
 initTheme();

--- a/src/windows/recorder/main.tsx
+++ b/src/windows/recorder/main.tsx
@@ -1,9 +1,11 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { SettingsProvider } from "@/lib/settings";
+import { installErrorLogging } from "@/lib/errorLogging";
 import { RecorderApp } from "./RecorderApp";
 import "../../styles.css";
 
+installErrorLogging("recorder");
 document.documentElement.classList.add("recorder-shell");
 
 ReactDOM.createRoot(document.getElementById("root")!).render(

--- a/src/windows/recorder/store.ts
+++ b/src/windows/recorder/store.ts
@@ -22,6 +22,7 @@ import type {
 } from "../../ipc/types";
 import { probeCameraPermission } from "./cameraAccess";
 import { flushCameraCaptureWithTimeout } from "./flushCamera";
+import { logClientError } from "@/lib/errorLogging";
 
 export type CaptureMode = CaptureSourceKind | "area" | "device";
 
@@ -208,6 +209,7 @@ function resetAreaCapture(
 export const useRecorderStore = create<RecorderStore>((set, get) => {
   const reportError = (message: string) => {
     set({ lastError: message });
+    logClientError("recorder", message);
   };
 
   return {
@@ -764,9 +766,19 @@ export const useRecorderStore = create<RecorderStore>((set, get) => {
 
 /** Turn an `AppError` (or anything) into a human string for the UI. */
 export function describeError(e: unknown): string {
-  if (e && typeof e === "object" && "kind" in e) {
-    const err = e as { kind: string; message?: string };
-    return err.message ?? err.kind;
+  if (e instanceof Error) return e.message || e.name;
+  if (typeof e === "string") return e;
+  if (e && typeof e === "object") {
+    const err = e as { kind?: unknown; message?: unknown };
+    if (typeof err.message === "string" && err.message.length > 0) {
+      return err.message;
+    }
+    if (typeof err.kind === "string") return err.kind;
+    try {
+      return JSON.stringify(e);
+    } catch {
+      /* fall through */
+    }
   }
   return String(e);
 }


### PR DESCRIPTION
Move Windows-friendly MP4 export out of the WebView: Pixi + WebCodecs emit Annex-B packets, Rust ffmpeg stream-copies into the file (with CFR timestamps). Soften 60fps bitrate (√fps) and tighten encode-queue depth at high fps. Persist errors-only to AppData logs/errors.log with tray “Open Error Log…” for friend-machine debugging.