### PR TITLE
fix: avoid macOS source picker freeze

### DIFF
--- a/src-tauri/src/recorder/backend/picker_sources.rs
+++ b/src-tauri/src/recorder/backend/picker_sources.rs
@@ -31,6 +31,8 @@ const BLOCKED_OWNER_BUNDLES: &[&str] = &[
 pub struct PickerWindow {
     pub id: u32,
     pub title: String,
+    pub width: u32,
+    pub height: u32,
 }
 
 pub fn parse_window_id(source_id: &str) -> Option<u32> {
@@ -122,34 +124,32 @@ pub fn display_for_window_frame(
     best.map(|(id, _)| id).or_else(|| display_for_rect(frame))
 }
 
-/// Pixel dimensions for a window at the display's backing scale (picker estimate).
-pub fn window_pixel_size(window_id: u32) -> Option<(u32, u32)> {
-    let content = shareable_content().ok()?;
-    let window = content.windows().into_iter().find(|w| w.get_window_id() == window_id)?;
-    let displays = content.displays();
-    let frame = window.get_frame();
-    let rect = CaptureRect {
-        x: frame.origin.x,
-        y: frame.origin.y,
-        width: frame.size.width,
-        height: frame.size.height,
-    };
-    let display_id = display_for_window_frame(&rect, &displays)?;
-    let scale = display_scale_factor(display_id);
-    Some(points_to_even_pixels(rect.width, rect.height, scale))
-}
-
 /// Windows a user would reasonably record — not desktop chrome or our own UI.
 pub fn recordable_windows() -> AppResult<Vec<PickerWindow>> {
     let content = shareable_content()?;
+    let displays = content.displays();
     let own_pid = std::process::id() as i32;
     let mut windows: Vec<PickerWindow> = content
         .windows()
         .iter()
         .filter(|w| is_recordable_window(w, own_pid))
-        .map(|w| PickerWindow {
-            id: w.get_window_id(),
-            title: window_label(w),
+        .map(|w| {
+            let frame = w.get_frame();
+            let rect = CaptureRect {
+                x: frame.origin.x,
+                y: frame.origin.y,
+                width: frame.size.width,
+                height: frame.size.height,
+            };
+            let (width, height) = display_for_window_frame(&rect, &displays)
+                .map(|id| points_to_even_pixels(rect.width, rect.height, display_scale_factor(id)))
+                .unwrap_or((0, 0));
+            PickerWindow {
+                id: w.get_window_id(),
+                title: window_label(w),
+                width,
+                height,
+            }
         })
         .collect();
 

--- a/src-tauri/src/recorder/backend/scap_backend.rs
+++ b/src-tauri/src/recorder/backend/scap_backend.rs
@@ -96,13 +96,12 @@ impl CaptureBackend for ScapBackend {
             {
                 continue;
             }
-            let (width, height) = picker_sources::window_pixel_size(window.id).unwrap_or((0, 0));
             sources.push(CaptureSource {
                 id: format!("window:{}", window.id),
                 kind: CaptureSourceKind::Window,
                 title: window.title,
-                width,
-                height,
+                width: window.width,
+                height: window.height,
                 is_primary: false,
                 thumbnail: preview.map(|p| p.png_base64),
             });

--- a/src/windows/recorder/RecorderToolbar.tsx
+++ b/src/windows/recorder/RecorderToolbar.tsx
@@ -69,6 +69,9 @@ export function RecorderToolbar({
   const captureMode = useRecorderStore((s) => s.captureMode);
   const areaSelection = useRecorderStore((s) => s.areaSelection);
   const selectedSourceId = useRecorderStore((s) => s.selectedSourceId);
+  // Quartz's legacy still-image APIs can block WindowServer on current macOS.
+  // Keep native thumbnails on Windows; source metadata is enough elsewhere.
+  const includePickerThumbnails = caps?.os === "windows";
   const selectedDeviceId = useRecorderStore((s) => s.selectedDeviceId);
 
   const [openMenu, setOpenMenu] = useState<MenuId | null>(null);
@@ -271,7 +274,9 @@ export function RecorderToolbar({
             onOpenChange={(open) => {
               if (open) {
                 useRecorderStore.getState().setCaptureMode("display");
-                void useRecorderStore.getState().refreshSources({ thumbnails: true });
+                void useRecorderStore.getState().refreshSources({
+                  thumbnails: includePickerThumbnails,
+                });
               }
               setMenuOpen("display", open);
             }}
@@ -286,7 +291,9 @@ export function RecorderToolbar({
               onOpenChange={(open) => {
                 if (open) {
                   useRecorderStore.getState().setCaptureMode("window");
-                  void useRecorderStore.getState().refreshSources({ thumbnails: true });
+                  void useRecorderStore.getState().refreshSources({
+                    thumbnails: includePickerThumbnails,
+                  });
                 }
                 setMenuOpen("window", open);
               }}
@@ -823,6 +830,7 @@ function SourceMenuContent({
   const select = useRecorderStore((s) => s.selectSource);
   const loading = useRecorderStore((s) => s.loadingSources);
   const refresh = useRecorderStore((s) => s.refreshSources);
+  const caps = usePlatformCapabilities();
   const filtered = sources.filter((s) => s.kind === mode);
 
   return (
@@ -836,7 +844,7 @@ function SourceMenuContent({
         <button
           type="button"
           className="rounded-sm px-1.5 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-          onClick={() => void refresh({ thumbnails: true })}
+          onClick={() => void refresh({ thumbnails: caps?.os === "windows" })}
         >
           {loading ? "…" : t("recorder.refresh")}
         </button>
@@ -935,7 +943,7 @@ function SourceThumbnail({
         className,
       )}
     >
-      {source.kind === "display" ? (index ?? 0) + 1 : "🪟"}
+      {source.kind === "display" ? (index ?? 0) + 1 : <AppWindowIcon />}
     </span>
   );
 }


### PR DESCRIPTION
## Summary
- avoid repeated `SCShareableContent` enumeration while building the macOS window list
- skip legacy Quartz source thumbnails on macOS, which can block WindowServer
- keep Windows thumbnails and show immediate source placeholders on macOS

## Testing
- `pnpm typecheck`
- `pnpm test:selfcheck` (42 passed)
- `cargo check --lib`
- `cargo test --lib recorder::backend::picker_sources::tests` (9 passed)