### PR TITLE
Add a back button to the recordings library title bar

### DIFF
--- a/src/lib/i18n/ar.ts
+++ b/src/lib/i18n/ar.ts
@@ -352,6 +352,8 @@ export const ar: Record<TranslationKey, string> = {
   "recorder.hud.hide": "إخفاء عناصر التحكم",
   "recorder.error.dismiss": "إغلاق",
 
+  "library.back": "رجوع",
+
   "library.search.placeholder": "البحث بالاسم…",
   "library.search.filter": "تصفية",
   "library.search.clear": "مسح البحث",

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -354,6 +354,8 @@ export const de: Record<TranslationKey, string> = {
   "recorder.hud.hide": "Steuerung ausblenden",
   "recorder.error.dismiss": "Schließen",
 
+  "library.back": "Zurück",
+
   "library.search.placeholder": "Nach Namen suchen…",
   "library.search.filter": "Filtern",
   "library.search.clear": "Suche löschen",

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -347,6 +347,8 @@ export const en = {
   "recorder.hud.hide": "Hide controls",
   "recorder.error.dismiss": "Dismiss",
 
+  "library.back": "Back",
+
   "library.search.placeholder": "Search by name…",
   "library.search.filter": "Filter",
   "library.search.clear": "Clear search",

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -359,6 +359,8 @@ export const es: Record<TranslationKey, string> = {
   "recorder.hud.hide": "Ocultar controles",
   "recorder.error.dismiss": "Cerrar",
 
+  "library.back": "Atrás",
+
   "library.search.placeholder": "Buscar por nombre…",
   "library.search.filter": "Filtrar",
   "library.search.clear": "Borrar búsqueda",

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -362,6 +362,8 @@ export const fr: Record<TranslationKey, string> = {
   "recorder.hud.hide": "Masquer les contrôles",
   "recorder.error.dismiss": "Fermer",
 
+  "library.back": "Retour",
+
   "library.search.placeholder": "Rechercher par nom…",
   "library.search.filter": "Filtrer",
   "library.search.clear": "Effacer la recherche",

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -359,6 +359,8 @@ export const it: Record<TranslationKey, string> = {
   "recorder.hud.hide": "Nascondi controlli",
   "recorder.error.dismiss": "Chiudi",
 
+  "library.back": "Indietro",
+
   "library.search.placeholder": "Cerca per nome…",
   "library.search.filter": "Filtra",
   "library.search.clear": "Cancella ricerca",

--- a/src/lib/i18n/ja.ts
+++ b/src/lib/i18n/ja.ts
@@ -349,6 +349,8 @@ export const ja: Record<TranslationKey, string> = {
   "recorder.hud.hide": "コントロールを隠す",
   "recorder.error.dismiss": "閉じる",
 
+  "library.back": "戻る",
+
   "library.search.placeholder": "名前で検索…",
   "library.search.filter": "フィルター",
   "library.search.clear": "検索をクリア",

--- a/src/lib/i18n/ko.ts
+++ b/src/lib/i18n/ko.ts
@@ -349,6 +349,8 @@ export const ko: Record<TranslationKey, string> = {
   "recorder.hud.hide": "컨트롤 숨기기",
   "recorder.error.dismiss": "닫기",
 
+  "library.back": "뒤로",
+
   "library.search.placeholder": "이름으로 검색…",
   "library.search.filter": "필터",
   "library.search.clear": "검색 지우기",

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -352,6 +352,8 @@ export const pt: Record<TranslationKey, string> = {
   "recorder.hud.hide": "Ocultar controlos",
   "recorder.error.dismiss": "Dispensar",
 
+  "library.back": "Voltar",
+
   "library.search.placeholder": "Pesquisar por nome…",
   "library.search.filter": "Filtrar",
   "library.search.clear": "Limpar pesquisa",

--- a/src/lib/i18n/ru.ts
+++ b/src/lib/i18n/ru.ts
@@ -352,6 +352,8 @@ export const ru: Record<TranslationKey, string> = {
   "recorder.hud.hide": "Скрыть панель",
   "recorder.error.dismiss": "Закрыть",
 
+  "library.back": "Назад",
+
   "library.search.placeholder": "Поиск по имени…",
   "library.search.filter": "Фильтр",
   "library.search.clear": "Очистить поиск",

--- a/src/lib/i18n/zh.ts
+++ b/src/lib/i18n/zh.ts
@@ -339,6 +339,8 @@ export const zh: Record<TranslationKey, string> = {
   "recorder.hud.hide": "隐藏控制栏",
   "recorder.error.dismiss": "关闭",
 
+  "library.back": "返回",
+
   "library.search.placeholder": "按名称搜索…",
   "library.search.filter": "筛选",
   "library.search.clear": "清除搜索",

--- a/src/windows/editor/EditorApp.tsx
+++ b/src/windows/editor/EditorApp.tsx
@@ -224,7 +224,14 @@ export function EditorApp() {
     return (
       <TooltipProvider delayDuration={200}>
         <div className="flex h-screen min-h-0 flex-col bg-background text-foreground">
-          <EditorTitleBar title={t("recorder.recordings")} />
+          <EditorTitleBar
+            title={t("recorder.recordings")}
+            onBack={
+              ready && !error && project
+                ? () => setShell("editor")
+                : undefined
+            }
+          />
           <div className="min-h-0 flex-1 overflow-y-auto">
             <RecordingsLibrary
               currentProjectId={projectId}

--- a/src/windows/editor/components/EditorTitleBar.tsx
+++ b/src/windows/editor/components/EditorTitleBar.tsx
@@ -6,7 +6,7 @@
  */
 
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import { Bug, Minus, Square, X } from "lucide-react";
+import { ArrowLeft, Bug, Minus, Square, X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -64,6 +64,8 @@ function WindowControls() {
 
 type Props = {
   title: string;
+  /** When set, a back button leads the bar (library shell with a project open). */
+  onBack?: () => void;
   /** When set, title is click-to-edit. Empty string clears the saved title. */
   onRename?: (next: string) => void;
   /** Value seeded into the input (use "" for untitled so the field starts empty). */
@@ -189,6 +191,7 @@ function EditableTitle({
 
 export function EditorTitleBar({
   title,
+  onBack,
   onRename,
   renameSeed,
   exportError = null,
@@ -224,6 +227,21 @@ export function EditorTitleBar({
         data-tauri-drag-region
         aria-hidden
       />
+
+      {onBack ? (
+        <div className="relative z-10 mr-auto flex items-center">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="pointer-events-auto gap-1.5 text-muted-foreground hover:text-foreground"
+            onClick={onBack}
+          >
+            <ArrowLeft className="size-4" aria-hidden />
+            {t("library.back")}
+          </Button>
+        </div>
+      ) : null}
 
       <div className="pointer-events-none absolute inset-x-0 top-px bottom-px flex items-center justify-center px-24">
         <div className="pointer-events-auto">


### PR DESCRIPTION
Hi @idboussadel @itsmylab, one more small quality of life improvement from my testing sessions.

When the editor switches to the in window recordings library, the title bar currently offers no way back. If you arrived there from an open project the only exit is clicking some recording, and clicking the one you were already editing feels like a workaround rather than navigation. A user in issue 1 also stumbled around this area, so I think a clear path back helps.

This PR adds a back button on the left side of the title bar, shown only while the library shell has a loaded project behind it, so a window opened directly into the library from the tray stays exactly as it is today. Clicking it returns to the editor shell without reloading the project. The label is localized and I added the new key to all eleven language files so the translation selfcheck stays green.

Typecheck, eslint and all selfchecks pass. Small diff, two components and the translation files. Thanks again for the quick energy on this project, it is honestly fun to contribute here.
