### PR TITLE
Make the volume slider and mute affect the exported file

### DIFF
--- a/src-tauri/src/commands/export.rs
+++ b/src-tauri/src/commands/export.rs
@@ -34,6 +34,9 @@ pub struct ExportAudioSegment {
 /// kept `segments` and optionally voice-enhanced. Runs FFmpeg off the UI thread;
 /// video is stream-copied so this is fast. `audio_source` is a bare filename in
 /// the project directory (e.g. `screen.mp4`).
+// One more argument than Clippy likes, but these are IPC parameters: bundling
+// them into a struct would change the shape the WebView sends.
+#[allow(clippy::too_many_arguments)]
 #[tauri::command]
 pub async fn mux_export_audio(
     state: State<'_, AppState>,
@@ -43,6 +46,7 @@ pub async fn mux_export_audio(
     segments: Vec<ExportAudioSegment>,
     preset: String,
     has_system_audio: bool,
+    gain: Option<f32>,
 ) -> AppResult<()> {
     if audio_source.contains(['/', '\\']) || audio_source.contains("..") {
         return Err(AppError::Other("invalid export audio source".into()));
@@ -57,7 +61,7 @@ pub async fn mux_export_audio(
     let preset = AudioEnhancePreset::parse(&preset);
 
     tauri::async_runtime::spawn_blocking(move || {
-        run_mux_export_audio(&video, &audio_path, &segs, preset, has_system_audio)
+        run_mux_export_audio(&video, &audio_path, &segs, preset, has_system_audio, gain.unwrap_or(1.0))
     })
     .await
     .map_err(|e| AppError::Other(format!("export audio mux task failed: {e}")))?
@@ -67,6 +71,7 @@ pub async fn mux_export_audio(
 /// video encode runs. `out_name` is a bare filename (joined under the project
 /// dir) so the WebView can read it back over `media://`. Returns the absolute
 /// sidecar path when written, or `null` when the recording is silent.
+#[allow(clippy::too_many_arguments)]
 #[tauri::command]
 pub async fn prepare_export_audio(
     state: State<'_, AppState>,
@@ -76,6 +81,7 @@ pub async fn prepare_export_audio(
     segments: Vec<ExportAudioSegment>,
     preset: String,
     has_system_audio: bool,
+    gain: Option<f32>,
 ) -> AppResult<Option<String>> {
     if audio_source.contains(['/', '\\']) || audio_source.contains("..") {
         return Err(AppError::Other("invalid export audio source".into()));
@@ -94,7 +100,7 @@ pub async fn prepare_export_audio(
     let preset = AudioEnhancePreset::parse(&preset);
 
     let wrote = tauri::async_runtime::spawn_blocking(move || {
-        run_prepare_export_audio(&audio_path, &out, &segs, preset, has_system_audio)
+        run_prepare_export_audio(&audio_path, &out, &segs, preset, has_system_audio, gain.unwrap_or(1.0))
     })
     .await
     .map_err(|e| AppError::Other(format!("export audio prepare task failed: {e}")))??;

--- a/src-tauri/src/recorder/encoder.rs
+++ b/src-tauri/src/recorder/encoder.rs
@@ -749,6 +749,28 @@ fn build_enhance_chain(preset: AudioEnhancePreset, has_system_audio: bool) -> Op
     Some(chain.join(","))
 }
 
+/// Fold the editor's volume slider into the audio filter chain.
+///
+/// `gain` is a linear multiplier taken from a 0..100 slider, so it only ever
+/// turns the audio down. Anything that is not a usable number leaves the level
+/// alone, so a bad value can never silently wipe out an export's audio. Full
+/// mute is not handled here: export skips the audio pass entirely in that case.
+fn with_gain(chain: Option<String>, gain: f32) -> Option<String> {
+    if !gain.is_finite() || gain <= 0.0 {
+        return chain;
+    }
+    let clamped = gain.min(1.0);
+    if (clamped - 1.0).abs() < f32::EPSILON {
+        return chain;
+    }
+    Some(match chain {
+        // Last in the chain, so the enhance preset's leveling and limiter still
+        // see the untouched signal and the slider stays predictable.
+        Some(existing) => format!("{existing},volume={clamped:.4}"),
+        None => format!("volume={clamped:.4}"),
+    })
+}
+
 /// Build the `-filter_complex` that trims `input_label`'s audio to `segments`
 /// (source seconds), concatenates them to match the trimmed video timeline, then
 /// applies `enhance`. Returns `(filter_complex, map_label)`; an empty filter
@@ -847,28 +869,34 @@ pub fn prepare_export_audio(
     segments: &[(f64, f64)],
     preset: AudioEnhancePreset,
     has_system_audio: bool,
+    gain: f32,
 ) -> AppResult<bool> {
     if !audio_source.is_file() || !mp4_has_audio_stream(audio_source) {
         return Ok(false);
     }
 
-    let enhance = build_enhance_chain(preset, has_system_audio);
-    if let Some(ref chain) = enhance {
+    let preset_chain = build_enhance_chain(preset, has_system_audio);
+    let had_preset = preset_chain.is_some();
+    if let Some(ref chain) = preset_chain {
         tracing::info!(
             %has_system_audio,
             filter = %chain,
             "export audio: applying podcast enhance"
         );
     }
+    let chain = with_gain(preset_chain, gain);
 
-    match run_prepare_export_audio_inner(audio_source, out_path, segments, enhance.as_deref()) {
+    match run_prepare_export_audio_inner(audio_source, out_path, segments, chain.as_deref()) {
         Ok(prepared) => Ok(prepared),
-        Err(e) if enhance.is_some() => {
+        // Only the enhance preset is worth retrying without. Gain is a single
+        // `volume` filter, so dropping it would just lose the user's setting.
+        Err(e) if had_preset => {
             tracing::warn!(
                 error = %e,
                 "export audio enhance failed; retrying without enhance"
             );
-            run_prepare_export_audio_inner(audio_source, out_path, segments, None)
+            let gain_only = with_gain(None, gain);
+            run_prepare_export_audio_inner(audio_source, out_path, segments, gain_only.as_deref())
         }
         Err(e) => Err(e),
     }
@@ -927,6 +955,7 @@ pub fn mux_export_audio(
     segments: &[(f64, f64)],
     preset: AudioEnhancePreset,
     has_system_audio: bool,
+    gain: f32,
 ) -> AppResult<()> {
     if !video_path.is_file() {
         return Err(AppError::Encoder("export mux: missing video".into()));
@@ -936,23 +965,28 @@ pub fn mux_export_audio(
         return Ok(());
     }
 
-    let enhance = build_enhance_chain(preset, has_system_audio);
-    if let Some(ref chain) = enhance {
+    let preset_chain = build_enhance_chain(preset, has_system_audio);
+    let had_preset = preset_chain.is_some();
+    if let Some(ref chain) = preset_chain {
         tracing::info!(
             %has_system_audio,
             filter = %chain,
             "export audio mux: applying podcast enhance"
         );
     }
+    let chain = with_gain(preset_chain, gain);
 
-    match run_mux_export_audio_inner(video_path, audio_source, segments, enhance.as_deref()) {
+    match run_mux_export_audio_inner(video_path, audio_source, segments, chain.as_deref()) {
         Ok(()) => Ok(()),
-        Err(e) if enhance.is_some() => {
+        // Only the enhance preset is worth retrying without. Gain is a single
+        // `volume` filter, so dropping it would just lose the user's setting.
+        Err(e) if had_preset => {
             tracing::warn!(
                 error = %e,
                 "export audio mux enhance failed; retrying without enhance"
             );
-            run_mux_export_audio_inner(video_path, audio_source, segments, None)
+            let gain_only = with_gain(None, gain);
+            run_mux_export_audio_inner(video_path, audio_source, segments, gain_only.as_deref())
         }
         Err(e) => Err(e),
     }
@@ -1244,6 +1278,49 @@ mod tests {
         assert!(f.contains("[0:a]atrim="));
         assert!(f.contains("concat=n=1:v=0:a=1[ac]"));
         assert_eq!(map, "[ac]");
+    }
+
+    #[test]
+    fn full_volume_adds_no_filter() {
+        assert_eq!(with_gain(None, 1.0), None);
+        assert_eq!(with_gain(Some("loudnorm".into()), 1.0), Some("loudnorm".into()));
+    }
+
+    #[test]
+    fn turning_the_volume_down_appends_a_volume_filter() {
+        assert_eq!(with_gain(None, 0.5), Some("volume=0.5000".into()));
+    }
+
+    /// Gain goes last so the enhance preset's leveling and limiter still see the
+    /// untouched signal.
+    #[test]
+    fn gain_runs_after_the_enhance_chain() {
+        let chain = with_gain(Some("highpass=f=80,alimiter=limit=0.95".into()), 0.25).unwrap();
+        assert_eq!(chain, "highpass=f=80,alimiter=limit=0.95,volume=0.2500");
+        assert!(
+            chain.find("alimiter") < chain.find("volume"),
+            "volume must come after the limiter, got {chain}"
+        );
+    }
+
+    /// A bad number must never silence an export. Muting is handled by skipping
+    /// the audio pass entirely, not by sending a zero gain down here.
+    #[test]
+    fn unusable_gain_leaves_the_level_alone() {
+        for bad in [f32::NAN, f32::INFINITY, 0.0, -1.0] {
+            assert_eq!(
+                with_gain(Some("loudnorm".into()), bad),
+                Some("loudnorm".into()),
+                "gain {bad} should have been ignored"
+            );
+            assert_eq!(with_gain(None, bad), None, "gain {bad} should add no filter");
+        }
+    }
+
+    /// The slider only attenuates, so a value above 1.0 must not boost.
+    #[test]
+    fn gain_never_boosts_above_unity() {
+        assert_eq!(with_gain(None, 4.0), None);
     }
 
     #[test]

--- a/src/ipc/bindings.ts
+++ b/src/ipc/bindings.ts
@@ -234,6 +234,8 @@ export const commands = {
     segments: { start: number; end: number }[];
     preset: "off" | "podcast";
     hasSystemAudio: boolean;
+    /** Linear volume multiplier from the editor slider; omit to leave it alone. */
+    gain?: number;
   }) => invoke<void>("mux_export_audio", args),
   /** Prepare a trimmed audio sidecar while video encodes; returns path or null when silent. */
   prepareExportAudio: (args: {
@@ -243,6 +245,8 @@ export const commands = {
     segments: { start: number; end: number }[];
     preset: "off" | "podcast";
     hasSystemAudio: boolean;
+    /** Linear volume multiplier from the editor slider; omit to leave it alone. */
+    gain?: number;
   }) => invoke<string | null>("prepare_export_audio", args),
   attachExportAudio: (args: { videoPath: string; audioPath: string }) =>
     invoke<void>("attach_export_audio", args),

--- a/src/windows/editor/export/exportVideo.ts
+++ b/src/windows/editor/export/exportVideo.ts
@@ -423,6 +423,18 @@ async function exportMp4(
 }
 
 /**
+ * The editor's volume slider as a linear multiplier for FFmpeg, or `null` when
+ * the track is muted. `null` means "export no audio at all" rather than
+ * "export silence", so a muted take produces a genuinely video-only file.
+ */
+function exportAudioGain(): number | null {
+  const { muted, volume } = useEditorStore.getState();
+  if (muted) return null;
+  const gain = Math.max(0, Math.min(1, volume / 100));
+  return gain <= 0 ? null : gain;
+}
+
+/**
  * Mux the recorded audio into the just-saved (video-only) export, trimmed to the
  * same kept segments the video uses. Rust runs FFmpeg (`-c:v copy`, so no video
  * re-encode) and no-ops for silent recordings.
@@ -433,6 +445,9 @@ async function muxRecordedAudio(
 ): Promise<void> {
   const { project, duration, segments } = useEditorStore.getState();
   if (!project) return;
+
+  const gain = exportAudioGain();
+  if (gain === null) return;
 
   const kept =
     segments.length > 0
@@ -449,6 +464,7 @@ async function muxRecordedAudio(
     segments: kept,
     preset,
     hasSystemAudio: project.capture.capturedSystemAudio,
+    gain,
   });
 }
 
@@ -466,6 +482,9 @@ async function prepareExportAudioTrack(
   const { project, duration, segments } = useEditorStore.getState();
   if (!project) return null;
 
+  const gain = exportAudioGain();
+  if (gain === null) return null;
+
   const kept =
     segments.length > 0
       ? segments.map((s) => ({ start: s.start, end: s.end }))
@@ -478,6 +497,7 @@ async function prepareExportAudioTrack(
     segments: kept,
     preset,
     hasSystemAudio: project.capture.capturedSystemAudio,
+    gain,
   });
   if (!absPath) return null;
   if (preset !== "off") {

--- a/src/windows/editor/store.ts
+++ b/src/windows/editor/store.ts
@@ -616,6 +616,8 @@ function enqueuePersist(get: () => EditorStore): void {
     cursorSettings,
     faceCam,
     aspectRatioPresetId,
+    muted,
+    volume,
   } = get();
   if (!projectId) return;
   const editorState = {
@@ -629,6 +631,8 @@ function enqueuePersist(get: () => EditorStore): void {
     cursorSettings,
     faceCam,
     aspectRatioPresetId,
+    muted,
+    volume,
     background: snapshotBackground(get()),
   };
   persistChain = persistChain
@@ -707,6 +711,8 @@ function parseEditorState(raw: unknown, duration: number): {
   faceCam?: FaceCamParams;
   aspectRatioPresetId?: AspectRatioPresetId;
   background?: PersistedBackground;
+  muted?: boolean;
+  volume?: number;
 } | null {
   if (!raw || typeof raw !== "object") return null;
   const data = raw as Record<string, unknown>;
@@ -742,6 +748,11 @@ function parseEditorState(raw: unknown, duration: number): {
   const aspectRatioPresetId = isAspectRatioPresetId(data.aspectRatioPresetId)
     ? data.aspectRatioPresetId
     : undefined;
+  const muted = typeof data.muted === "boolean" ? data.muted : undefined;
+  const volume =
+    typeof data.volume === "number" && Number.isFinite(data.volume)
+      ? Math.max(0, Math.min(100, data.volume))
+      : undefined;
   return {
     segments: segments && segments.length > 0 ? segments : createFullSegment(duration),
     zoomFragments,
@@ -754,6 +765,8 @@ function parseEditorState(raw: unknown, duration: number): {
     faceCam,
     aspectRatioPresetId,
     background: parsePersistedBackground(data.background),
+    muted,
+    volume,
   };
 }
 
@@ -1009,6 +1022,8 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
       cursorSettings,
       faceCam,
       aspectRatioPresetId,
+      muted: parsed?.muted ?? get().muted,
+      volume: parsed?.volume ?? get().volume,
       mediaInitialized: true,
     });
 
@@ -1259,9 +1274,11 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
   },
   setMuted(muted) {
     set({ muted });
+    schedulePersist(get);
   },
   setVolume(volume) {
     set({ volume });
+    schedulePersist(get);
   },
   setExporting(exporting) {
     set({ exporting, exportProgress: exporting ? 0 : get().exportProgress });


### PR DESCRIPTION
## The problem

The editor's volume slider and mute button only changed the preview player,
so what you heard while editing was not what came out of the export.

- `PreviewStage.tsx` applies both to the preview `<video>` element only.
- `exportCompositor.ts` sets `video.muted = true` for the export pass, and
  the audio is added separately by FFmpeg.
- `prepare_export_audio` and `mux_export_audio` had no volume parameter, so
  the recorded audio always went in at full level.

Neither value was in the saved editor state either, so muting a project and
reopening it brought the sound straight back.

Net effect: someone can mute a recording, export it, and still ship audio at
full volume.

## The change

Mute now means no audio track in the file at all, rather than a silent one.
The volume slider is applied as a gain when the audio is encoded. Both
values are saved with the project.

- Rust: `with_gain` folds the slider into the existing audio filter chain as
  a `volume` filter. It sits last so the enhance preset's leveling and
  limiter still see the untouched signal.
- Rust: `gain` is `Option<f32>` on both commands, so leaving it out behaves
  exactly as before.
- UI: one `exportAudioGain()` helper returns the gain, or `null` when muted.
  Both audio paths (prepare and the mux fallback) skip the audio work on
  `null`.
- UI: `volume` and `muted` are saved and restored with the rest of the
  editor state, and the setters now trigger a save.

The slider is 0 to 100, so the gain only ever turns audio down. Anything
that is not a usable number leaves the level alone, so a bad value cannot
silently wipe out an export's audio.

## Tests

Five unit tests for `with_gain`, covering full volume adding no filter,
attenuation, ordering after the limiter, unusable values being ignored, and
no boost above unity.

I also checked the generated filter chain against FFmpeg directly. With
`volume=0.25` the measured mean volume dropped from -21.1 dB to -33.2 dB,
which is the -12.04 dB the maths predicts.

## Checks

- `cargo test`: 149 passed
- `pnpm test`: typecheck clean, 45 self-checks passed
- `pnpm lint`: no new problems
- `cargo clippy`: no new warnings. The two commands gained an argument, so
  they carry the same `too_many_arguments` allow already used in
  `recorder/mod.rs`, since these are IPC parameters.
- Built the full app bundle on macOS 26.3, Apple Silicon (`pnpm tauri build`), installed it and confirmed it launches and the code signature verifies.

