### PR TITLE
Translate the remaining recordings screen text

### DIFF
--- a/src/lib/i18n/ar.ts
+++ b/src/lib/i18n/ar.ts
@@ -362,6 +362,15 @@ export const ar: Record<TranslationKey, string> = {
 
   "library.back": "رجوع",
 
+  "library.title": "التسجيلات",
+  "library.subtitle": "تبقى مقاطع الفيديو على هذا الجهاز. انقر على تسجيل لفتح المحرر.",
+  "library.empty": "لا توجد تسجيلات بعد. سجّل من شريط القوائم ثم عد إلى هنا.",
+  "library.delete": "حذف",
+  "library.deleteConfirm": "حذف «{title}»؟ لا يمكن التراجع عن هذا الإجراء.",
+  "library.rowActions": "إجراءات {title}",
+  "library.loadFailed": "فشل تحميل التسجيلات",
+  "library.deleteFailed": "فشل الحذف",
+
   "library.search.placeholder": "البحث بالاسم…",
   "library.search.filter": "تصفية",
   "library.search.clear": "مسح البحث",

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -364,6 +364,15 @@ export const de: Record<TranslationKey, string> = {
 
   "library.back": "Zurück",
 
+  "library.title": "Aufnahmen",
+  "library.subtitle": "Die Videos bleiben auf diesem Gerät. Auf eine Aufnahme klicken, um den Editor zu öffnen.",
+  "library.empty": "Noch keine Aufnahmen. Über die Menüleiste aufnehmen und dann hierher zurückkommen.",
+  "library.delete": "Löschen",
+  "library.deleteConfirm": "„{title}“ löschen? Das kann nicht widerrufen werden.",
+  "library.rowActions": "Aktionen für {title}",
+  "library.loadFailed": "Aufnahmen konnten nicht geladen werden",
+  "library.deleteFailed": "Löschen fehlgeschlagen",
+
   "library.search.placeholder": "Nach Namen suchen…",
   "library.search.filter": "Filtern",
   "library.search.clear": "Suche löschen",

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -357,6 +357,15 @@ export const en = {
 
   "library.back": "Back",
 
+  "library.title": "Recordings",
+  "library.subtitle": "Your videos stay on this device. Click a recording to open the editor.",
+  "library.empty": "No recordings yet. Capture from the menubar tray, then come back here.",
+  "library.delete": "Delete",
+  "library.deleteConfirm": "Delete “{title}”? This cannot be undone.",
+  "library.rowActions": "Actions for {title}",
+  "library.loadFailed": "Failed to load recordings",
+  "library.deleteFailed": "Failed to delete",
+
   "library.search.placeholder": "Search by name…",
   "library.search.filter": "Filter",
   "library.search.clear": "Clear search",

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -369,6 +369,15 @@ export const es: Record<TranslationKey, string> = {
 
   "library.back": "Atrás",
 
+  "library.title": "Grabaciones",
+  "library.subtitle": "Tus vídeos permanecen en este dispositivo. Haz clic en una grabación para abrir el editor.",
+  "library.empty": "Aún no hay grabaciones. Captura desde la barra de menús y vuelve aquí.",
+  "library.delete": "Eliminar",
+  "library.deleteConfirm": "¿Eliminar «{title}»? Esta acción no se puede deshacer.",
+  "library.rowActions": "Acciones para {title}",
+  "library.loadFailed": "No se pudieron cargar las grabaciones",
+  "library.deleteFailed": "No se pudo eliminar",
+
   "library.search.placeholder": "Buscar por nombre…",
   "library.search.filter": "Filtrar",
   "library.search.clear": "Borrar búsqueda",

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -372,6 +372,15 @@ export const fr: Record<TranslationKey, string> = {
 
   "library.back": "Retour",
 
+  "library.title": "Enregistrements",
+  "library.subtitle": "Vos vidéos restent sur cet appareil. Cliquez sur un enregistrement pour ouvrir l’éditeur.",
+  "library.empty": "Aucun enregistrement pour l’instant. Lancez une capture depuis la barre de menus, puis revenez ici.",
+  "library.delete": "Supprimer",
+  "library.deleteConfirm": "Supprimer « {title} » ? Cette action est irréversible.",
+  "library.rowActions": "Actions pour {title}",
+  "library.loadFailed": "Échec du chargement des enregistrements",
+  "library.deleteFailed": "Échec de la suppression",
+
   "library.search.placeholder": "Rechercher par nom…",
   "library.search.filter": "Filtrer",
   "library.search.clear": "Effacer la recherche",

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -369,6 +369,15 @@ export const it: Record<TranslationKey, string> = {
 
   "library.back": "Indietro",
 
+  "library.title": "Registrazioni",
+  "library.subtitle": "I tuoi video restano su questo dispositivo. Fai clic su una registrazione per aprire l’editor.",
+  "library.empty": "Nessuna registrazione per ora. Avvia una cattura dalla barra dei menu, poi torna qui.",
+  "library.delete": "Elimina",
+  "library.deleteConfirm": "Eliminare «{title}»? L’operazione non può essere annullata.",
+  "library.rowActions": "Azioni per {title}",
+  "library.loadFailed": "Caricamento delle registrazioni non riuscito",
+  "library.deleteFailed": "Eliminazione non riuscita",
+
   "library.search.placeholder": "Cerca per nome…",
   "library.search.filter": "Filtra",
   "library.search.clear": "Cancella ricerca",

--- a/src/lib/i18n/ja.ts
+++ b/src/lib/i18n/ja.ts
@@ -359,6 +359,15 @@ export const ja: Record<TranslationKey, string> = {
 
   "library.back": "戻る",
 
+  "library.title": "録画",
+  "library.subtitle": "動画はこのデバイスに保存されます。録画をクリックするとエディタが開きます。",
+  "library.empty": "まだ録画がありません。メニューバーから録画して、ここに戻ってください。",
+  "library.delete": "削除",
+  "library.deleteConfirm": "「{title}」を削除しますか？この操作は取り消せません。",
+  "library.rowActions": "{title} の操作",
+  "library.loadFailed": "録画を読み込めませんでした",
+  "library.deleteFailed": "削除できませんでした",
+
   "library.search.placeholder": "名前で検索…",
   "library.search.filter": "フィルター",
   "library.search.clear": "検索をクリア",

--- a/src/lib/i18n/ko.ts
+++ b/src/lib/i18n/ko.ts
@@ -359,6 +359,15 @@ export const ko: Record<TranslationKey, string> = {
 
   "library.back": "뒤로",
 
+  "library.title": "녹화",
+  "library.subtitle": "영상은 이 기기에 저장됩니다. 녹화를 클릭하면 편집기가 열립니다.",
+  "library.empty": "아직 녹화가 없습니다. 메뉴 바에서 녹화한 뒤 여기로 돌아오세요.",
+  "library.delete": "삭제",
+  "library.deleteConfirm": "“{title}”을 삭제할까요? 이 작업은 취소할 수 없습니다.",
+  "library.rowActions": "{title} 작업",
+  "library.loadFailed": "녹화를 불러오지 못했습니다",
+  "library.deleteFailed": "삭제하지 못했습니다",
+
   "library.search.placeholder": "이름으로 검색…",
   "library.search.filter": "필터",
   "library.search.clear": "검색 지우기",

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -362,6 +362,15 @@ export const pt: Record<TranslationKey, string> = {
 
   "library.back": "Voltar",
 
+  "library.title": "Gravações",
+  "library.subtitle": "Os seus vídeos ficam neste dispositivo. Clique numa gravação para abrir o editor.",
+  "library.empty": "Ainda não há gravações. Faça uma captura a partir da barra de menus e volte aqui.",
+  "library.delete": "Eliminar",
+  "library.deleteConfirm": "Eliminar «{title}»? Esta ação não pode ser anulada.",
+  "library.rowActions": "Ações para {title}",
+  "library.loadFailed": "Falha ao carregar as gravações",
+  "library.deleteFailed": "Falha ao eliminar",
+
   "library.search.placeholder": "Pesquisar por nome…",
   "library.search.filter": "Filtrar",
   "library.search.clear": "Limpar pesquisa",

--- a/src/lib/i18n/ru.ts
+++ b/src/lib/i18n/ru.ts
@@ -362,6 +362,15 @@ export const ru: Record<TranslationKey, string> = {
 
   "library.back": "Назад",
 
+  "library.title": "Записи",
+  "library.subtitle": "Ваши видео остаются на этом устройстве. Нажмите на запись, чтобы открыть редактор.",
+  "library.empty": "Записей пока нет. Начните запись из строки меню и вернитесь сюда.",
+  "library.delete": "Удалить",
+  "library.deleteConfirm": "Удалить «{title}»? Это действие нельзя отменить.",
+  "library.rowActions": "Действия для {title}",
+  "library.loadFailed": "Не удалось загрузить записи",
+  "library.deleteFailed": "Не удалось удалить",
+
   "library.search.placeholder": "Поиск по имени…",
   "library.search.filter": "Фильтр",
   "library.search.clear": "Очистить поиск",

--- a/src/lib/i18n/zh.ts
+++ b/src/lib/i18n/zh.ts
@@ -349,6 +349,15 @@ export const zh: Record<TranslationKey, string> = {
 
   "library.back": "返回",
 
+  "library.title": "录制",
+  "library.subtitle": "你的视频保存在本设备上。点击录制即可打开编辑器。",
+  "library.empty": "还没有录制。从菜单栏录制后再回到这里。",
+  "library.delete": "删除",
+  "library.deleteConfirm": "删除“{title}”？此操作无法撤消。",
+  "library.rowActions": "{title} 的操作",
+  "library.loadFailed": "无法加载录制",
+  "library.deleteFailed": "无法删除",
+
   "library.search.placeholder": "按名称搜索…",
   "library.search.filter": "筛选",
   "library.search.clear": "清除搜索",

--- a/src/windows/editor/components/RecordingsLibrary.tsx
+++ b/src/windows/editor/components/RecordingsLibrary.tsx
@@ -15,9 +15,12 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { commands } from "@/ipc/bindings";
 import type { ProjectSummary } from "@/ipc/types";
+import type { TranslationKey } from "@/lib/i18n";
 import { useI18n } from "@/lib/settings";
 import { cn } from "@/lib/utils";
 import { mediaUrl } from "../store";
+
+type Translate = (key: TranslationKey, params?: Record<string, string | number>) => string;
 
 function formatCreatedAt(iso: string): string {
   const d = new Date(iso);
@@ -28,14 +31,18 @@ function formatCreatedAt(iso: string): string {
   }).format(d);
 }
 
-function displayTitle(p: ProjectSummary): string {
-  return p.title?.trim() || "Untitled recording";
+function displayTitle(p: ProjectSummary, t: Translate): string {
+  return p.title?.trim() || t("app.untitled");
 }
 
-function matchesNameFilter(project: ProjectSummary, query: string): boolean {
+function matchesNameFilter(
+  project: ProjectSummary,
+  query: string,
+  t: Translate,
+): boolean {
   const needle = query.trim().toLowerCase();
   if (!needle) return true;
-  return displayTitle(project).toLowerCase().includes(needle);
+  return displayTitle(project, t).toLowerCase().includes(needle);
 }
 
 /** Poster from `thumbnail.jpg` only — backfill once if the file is missing. */
@@ -113,8 +120,8 @@ export function RecordingsLibrary({ currentProjectId, onOpenProject }: Recording
   const searchRef = useRef<HTMLInputElement>(null);
 
   const filteredProjects = useMemo(
-    () => projects.filter((p) => matchesNameFilter(p, nameFilter)),
-    [projects, nameFilter],
+    () => projects.filter((p) => matchesNameFilter(p, nameFilter, t)),
+    [projects, nameFilter, t],
   );
 
   const applyNameFilter = useCallback(() => {
@@ -135,16 +142,16 @@ export function RecordingsLibrary({ currentProjectId, onOpenProject }: Recording
         setError(null);
       });
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to load recordings");
+      setError(e instanceof Error ? e.message : t("library.loadFailed"));
     }
-  }, []);
+  }, [t]);
 
   useEffect(() => {
     void refresh();
   }, [refresh]);
 
   const remove = async (id: string, title: string) => {
-    if (!window.confirm(`Delete “${title}”? This cannot be undone.`)) return;
+    if (!window.confirm(t("library.deleteConfirm", { title }))) return;
     setBusyId(id);
     try {
       await commands.deleteProject(id);
@@ -152,7 +159,7 @@ export function RecordingsLibrary({ currentProjectId, onOpenProject }: Recording
         setProjects((prev) => prev.filter((p) => p.id !== id));
       });
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to delete");
+      setError(e instanceof Error ? e.message : t("library.deleteFailed"));
     } finally {
       setBusyId(null);
     }
@@ -161,10 +168,10 @@ export function RecordingsLibrary({ currentProjectId, onOpenProject }: Recording
   return (
     <div className="flex min-h-full flex-col bg-background text-foreground">
       <header className="mx-auto w-full max-w-6xl shrink-0 px-8 pb-2 pt-10">
-        <h1 className="text-3xl font-semibold tracking-tight text-foreground">Recordings</h1>
-        <p className="mt-2 text-sm text-muted-foreground">
-          Your videos stay on this device. Click a recording to open the editor.
-        </p>
+        <h1 className="text-3xl font-semibold tracking-tight text-foreground">
+          {t("library.title")}
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">{t("library.subtitle")}</p>
       </header>
 
       <div className="mx-auto w-full max-w-6xl flex-1 px-8 pb-12 pt-6">
@@ -219,7 +226,7 @@ export function RecordingsLibrary({ currentProjectId, onOpenProject }: Recording
 
         {projects.length === 0 ? (
           <p className="py-20 text-center text-sm text-muted-foreground">
-            No recordings yet. Capture from the menubar tray, then come back here.
+            {t("library.empty")}
           </p>
         ) : filteredProjects.length === 0 ? (
           <p className="py-20 text-center text-sm text-muted-foreground">
@@ -228,7 +235,7 @@ export function RecordingsLibrary({ currentProjectId, onOpenProject }: Recording
         ) : (
           <ul className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
             {filteredProjects.map((p) => {
-              const title = displayTitle(p);
+              const title = displayTitle(p, t);
               const busy = busyId === p.id;
               const isCurrent = p.id === currentProjectId;
               return (
@@ -271,7 +278,7 @@ export function RecordingsLibrary({ currentProjectId, onOpenProject }: Recording
                             size="icon"
                             className="size-8 shrink-0 text-muted-foreground"
                             disabled={busy}
-                            aria-label={`Actions for ${title}`}
+                            aria-label={t("library.rowActions", { title })}
                           >
                             <MoreHorizontal className="size-4" />
                           </Button>
@@ -282,7 +289,7 @@ export function RecordingsLibrary({ currentProjectId, onOpenProject }: Recording
                             onClick={() => void remove(p.id, title)}
                           >
                             <Trash2 className="size-4" />
-                            Delete
+                            {t("library.delete")}
                           </DropdownMenuItem>
                         </DropdownMenuContent>
                       </DropdownMenu>


### PR DESCRIPTION
## The problem

The recordings screen is partly translated already (search box, Back, the
no-match message), but the rest was still hardcoded English for every
language:

- the `Recordings` heading and the subtitle under it
- the empty state, "No recordings yet…"
- the `Delete` menu item
- the delete confirmation
- the row menu label, "Actions for …"
- two error messages, on load failure and delete failure
- the fallback title `Untitled recording`, even though an `app.untitled`
  key already exists and is translated in all eleven languages

The recorder popover is fully translated, so this screen stood out.

## The change

Adds the eight missing keys to all eleven language files and switches the
component over to them. The fallback title now uses the `app.untitled` key
that was already there.

`displayTitle` and `matchesNameFilter` take the translate function as an
argument, so the fallback follows the selected language and updates when it
changes. The `Translate` alias is declared locally, the same way
`lib/updateToast.tsx` does it.

The English wording is unchanged. This is only about making the existing
copy translatable, so there is no new copy to review.

## On the translations

I wrote these to match the terms each language file already uses, for
example Aufnahme for German, grabación for Spanish, 録画 for Japanese, so
the new strings read consistently with the existing ones.

Also matched each file's existing tone: German avoids "Sie" and uses the
impersonal form the rest of that file uses, and Portuguese stays European
(ficheiro, ecrã). Quote marks follow local convention, so „…" in German,
« … » in French, 「…」 in Japanese.

Happy to adjust any wording a native speaker would phrase differently.

## Checks

- `pnpm test`: typecheck clean, 45 self-checks passed. Because each language
  file is typed as `Record<TranslationKey, string>`, a clean typecheck is
  proof that all eleven files have all eight keys, with none missing or
  misspelled.
- `pnpm lint`: 7 problems, exactly the same as on `main`. No new warnings.
- `pnpm build`: production bundle builds clean on macOS 26.3, Apple Silicon.

