### PR TITLE
Ask before deleting a custom background image

### DIFF
--- a/src/lib/i18n/ar.ts
+++ b/src/lib/i18n/ar.ts
@@ -112,6 +112,7 @@ export const ar: Record<TranslationKey, string> = {
   "look.custom": "مخصص",
   "look.uploadImage": "رفع صورة",
   "look.deleteImage": "حذف الصورة",
+  "look.deleteImageConfirm": "حذف صورة الخلفية هذه؟ لا يمكن التراجع عن هذا الإجراء.",
   "look.start": "البداية",
   "look.end": "النهاية",
   "look.angle": "الزاوية",

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -112,6 +112,7 @@ export const de: Record<TranslationKey, string> = {
   "look.custom": "Eigene",
   "look.uploadImage": "Bild hochladen",
   "look.deleteImage": "Bild löschen",
+  "look.deleteImageConfirm": "Dieses Hintergrundbild löschen? Das kann nicht widerrufen werden.",
   "look.start": "Start",
   "look.end": "Ende",
   "look.angle": "Winkel",

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -112,6 +112,7 @@ export const en = {
   "look.custom": "Custom",
   "look.uploadImage": "Upload image",
   "look.deleteImage": "Delete image",
+  "look.deleteImageConfirm": "Delete this background image? This cannot be undone.",
   "look.start": "Start",
   "look.end": "End",
   "look.angle": "Angle",

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -114,6 +114,7 @@ export const es: Record<TranslationKey, string> = {
   "look.custom": "Personalizado",
   "look.uploadImage": "Subir imagen",
   "look.deleteImage": "Eliminar imagen",
+  "look.deleteImageConfirm": "¿Eliminar esta imagen de fondo? Esta acción no se puede deshacer.",
   "look.start": "Inicio",
   "look.end": "Fin",
   "look.angle": "Ángulo",

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -115,6 +115,7 @@ export const fr: Record<TranslationKey, string> = {
   "look.custom": "Personnalisé",
   "look.uploadImage": "Importer une image",
   "look.deleteImage": "Supprimer l'image",
+  "look.deleteImageConfirm": "Supprimer cette image d’arrière-plan ? Cette action est irréversible.",
   "look.start": "Début",
   "look.end": "Fin",
   "look.angle": "Angle",

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -114,6 +114,7 @@ export const it: Record<TranslationKey, string> = {
   "look.custom": "Personalizzato",
   "look.uploadImage": "Carica immagine",
   "look.deleteImage": "Elimina immagine",
+  "look.deleteImageConfirm": "Eliminare questa immagine di sfondo? L’operazione non può essere annullata.",
   "look.start": "Inizio",
   "look.end": "Fine",
   "look.angle": "Angolo",

--- a/src/lib/i18n/ja.ts
+++ b/src/lib/i18n/ja.ts
@@ -111,6 +111,7 @@ export const ja: Record<TranslationKey, string> = {
   "look.custom": "カスタム",
   "look.uploadImage": "画像をアップロード",
   "look.deleteImage": "画像を削除",
+  "look.deleteImageConfirm": "この背景画像を削除しますか？この操作は取り消せません。",
   "look.start": "開始",
   "look.end": "終了",
   "look.angle": "角度",

--- a/src/lib/i18n/ko.ts
+++ b/src/lib/i18n/ko.ts
@@ -111,6 +111,7 @@ export const ko: Record<TranslationKey, string> = {
   "look.custom": "사용자 지정",
   "look.uploadImage": "이미지 업로드",
   "look.deleteImage": "이미지 삭제",
+  "look.deleteImageConfirm": "이 배경 이미지를 삭제할까요? 이 작업은 취소할 수 없습니다.",
   "look.start": "시작",
   "look.end": "끝",
   "look.angle": "각도",

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -112,6 +112,7 @@ export const pt: Record<TranslationKey, string> = {
   "look.custom": "Personalizado",
   "look.uploadImage": "Carregar imagem",
   "look.deleteImage": "Eliminar imagem",
+  "look.deleteImageConfirm": "Eliminar esta imagem de fundo? Esta ação não pode ser anulada.",
   "look.start": "Início",
   "look.end": "Fim",
   "look.angle": "Ângulo",

--- a/src/lib/i18n/ru.ts
+++ b/src/lib/i18n/ru.ts
@@ -112,6 +112,7 @@ export const ru: Record<TranslationKey, string> = {
   "look.custom": "Свой",
   "look.uploadImage": "Загрузить изображение",
   "look.deleteImage": "Удалить изображение",
+  "look.deleteImageConfirm": "Удалить это фоновое изображение? Это действие нельзя отменить.",
   "look.start": "Начало",
   "look.end": "Конец",
   "look.angle": "Угол",

--- a/src/lib/i18n/zh.ts
+++ b/src/lib/i18n/zh.ts
@@ -107,6 +107,7 @@ export const zh: Record<TranslationKey, string> = {
   "look.custom": "自定义",
   "look.uploadImage": "上传图片",
   "look.deleteImage": "删除图片",
+  "look.deleteImageConfirm": "删除此背景图片？此操作无法撤消。",
   "look.start": "起点",
   "look.end": "终点",
   "look.angle": "角度",

--- a/src/windows/editor/components/LookPanel.tsx
+++ b/src/windows/editor/components/LookPanel.tsx
@@ -222,6 +222,9 @@ function ImageGrid() {
               onClick={() => {
                 const id = menu.id;
                 closeMenu();
+                // Deleting the image removes the uploaded file for good, so ask
+                // first. Same guard the recordings list uses before a delete.
+                if (!window.confirm(t("look.deleteImageConfirm"))) return;
                 void deleteCustomBackground(id);
               }}
             >


### PR DESCRIPTION
## The problem

Right clicking a custom background image and choosing "Delete image" calls
`deleteCustomBackground` immediately, in `LookPanel.tsx`. That deletes the
uploaded file from the project directory. There is no confirmation and no
undo, so a misclick loses an image the user had to pick off their disk.

The menu item appears right under the pointer on right click, which makes it
easy to hit by accident. It is also the only destructive action in the
editor without a guard: deleting a project asks first.

## The change

Ask before deleting, using the same `window.confirm` guard the recordings
list uses, so the two destructive actions behave the same way. The message
is added in all eleven languages.

I kept `window.confirm` deliberately, to match what the recordings list
already does rather than introduce a second pattern for the same kind of
prompt. If you would rather these moved to the app's own dialog component,
that feels like a separate change covering both places at once, and I am
happy to do that instead.

## Checks

- `pnpm test`: typecheck clean, 45 self-checks passed. The language files are
  typed as `Record<TranslationKey, string>`, so a clean typecheck confirms the
  new key is present in all eleven.
- `pnpm lint`: 7 problems, the same as on `main`. No new warnings.
- `pnpm build`: production bundle builds clean.
- Reviewed on macOS 26.3 on Apple Silicon. I have not click-tested the prompt
  itself, since it is a `window.confirm` in a right-click menu; the change is
  the one-line guard shown above.

