### PR TITLE
fix(annotation): get the overlay off screen when its GPU context dies

### DIFF
--- a/src/annotation/engine.ts
+++ b/src/annotation/engine.ts
@@ -331,6 +331,26 @@ export class AnnotationEngine {
     return this.layerHidden;
   }
 
+  /**
+   * Rebuild both canvas contexts and repaint committed strokes.
+   *
+   * Same work as a resize, exposed because a lost 2D context needs exactly
+   * this: the old `CanvasRenderingContext2D` handles are dead, and the ink
+   * only survives because `history` is plain data rather than pixels.
+   */
+  recoverContexts() {
+    this.onResize();
+  }
+
+  /** True when the view canvas's 2D context has been lost by the compositor. */
+  isContextLost(): boolean {
+    // `isContextLost` is Chromium 117+; older engines simply never report loss.
+    const ctx = this.viewCtx as CanvasRenderingContext2D & {
+      isContextLost?: () => boolean;
+    };
+    return typeof ctx.isContextLost === "function" ? ctx.isContextLost() : false;
+  }
+
   private onResize() {
     const w = window.innerWidth;
     const h = window.innerHeight;

--- a/src/windows/annotation/AnnotationApp.tsx
+++ b/src/windows/annotation/AnnotationApp.tsx
@@ -45,7 +45,19 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Slider } from "@/components/ui/slider";
 import { commands } from "@/ipc/bindings";
-import { logClientInfo } from "@/lib/errorLogging";
+import { logClientError, logClientInfo } from "@/lib/errorLogging";
+import {
+  attachCanvas2dContextLoss,
+  planOverlayRecovery,
+  type OverlayRecoveryState,
+} from "./overlayGpuGuard";
+
+/**
+ * How often to check that the overlay's drawing context is still alive. Cheap
+ * enough to be invisible (one boolean read) and fast enough that a dead
+ * fullscreen overlay is not left covering the desktop for long.
+ */
+const CONTEXT_WATCHDOG_MS = 2_000;
 import { cn } from "@/lib/utils";
 
 const ANNOTATION_ESCAPE_EVENT = "annotation://escape";
@@ -118,6 +130,10 @@ export function AnnotationApp() {
   // stays mounted while hidden. Track native visibility to suspend the idle
   // cursor-poll when off-screen — the window is created to be shown, so `true`.
   const [overlayVisible, setOverlayVisible] = useState(true);
+  // Mirror of `overlayVisible` for the context-loss handler, which is installed
+  // once and would otherwise close over the mount-time value.
+  const overlayVisibleRef = useRef(true);
+  overlayVisibleRef.current = overlayVisible;
 
   const passThrough = tool === "select" && panel === null;
 
@@ -182,7 +198,87 @@ export function AnnotationApp() {
     canvas.addEventListener("pointerup", onUp);
     canvas.addEventListener("pointercancel", onUp);
 
+    // GPU context loss on a fullscreen transparent always-on-top window is not
+    // a rendering glitch — the surface composites opaque and the user's whole
+    // desktop goes black mid-recording (#25). Hide first, ask questions after:
+    // a hidden window cannot paint over anything, and the ink is history data
+    // so nothing is lost by rebuilding.
+    let recovery: OverlayRecoveryState = { attempts: 0, lastAttemptAtMs: null };
+    let recovering = false;
+    const handleContextLoss = () => {
+      if (recovering) return;
+      recovering = true;
+      const win = getCurrentWindow();
+      // Hide before anything else — this is the step that gets the black
+      // rectangle off the user's desktop. Everything after it is cleanup.
+      if (overlayVisibleRef.current) {
+        void win.hide().catch(() => undefined);
+      }
+
+      const { action, next } = planOverlayRecovery(recovery, Date.now());
+      recovery = next;
+      logClientError(
+        "annotation-overlay",
+        new Error(
+          `2D context lost (attempt ${next.attempts}); overlay hidden, action=${action}`,
+        ),
+      );
+
+      if (action === "stayHidden") {
+        // Repeated loss means the GPU process is not coming back. Showing the
+        // overlay again would just black the desktop out a fourth time, so
+        // the take continues without live ink.
+        void emit("annotation://closed");
+        void commands.hideAnnotationOverlay().catch(() => undefined);
+        recovering = false;
+        return;
+      }
+
+      try {
+        engine.recoverContexts();
+      } catch (e) {
+        logClientError("annotation-overlay", e);
+      }
+      // Only come back once the context actually took. Showing a still-lost
+      // surface is exactly the black screen being defended against.
+      if (engine.isContextLost()) {
+        void emit("annotation://closed");
+        void commands.hideAnnotationOverlay().catch(() => undefined);
+      } else if (overlayVisibleRef.current) {
+        // Only restore an overlay that was actually on screen. A context can be
+        // lost while the user has the overlay closed, and showing it again
+        // would put a toolbar back over their screen that they dismissed.
+        void win.show().catch(() => undefined);
+      }
+      recovering = false;
+    };
+
+    const detachContextLoss = attachCanvas2dContextLoss(canvas, {
+      onLost: handleContextLoss,
+      onRestored: () => {
+        logClientInfo("annotation-overlay", "2D context restored");
+        try {
+          engine.recoverContexts();
+        } catch (e) {
+          logClientError("annotation-overlay", e);
+        }
+      },
+    });
+
+    // The event is the fast path, not the only one. A compositor fault can leave
+    // the context dead without our listener ever seeing `contextlost` — and the
+    // window whose surface is black is exactly the window that stopped telling
+    // us things. Poll cheaply so the desktop is never left covered by a dead
+    // overlay waiting for an event that is not coming.
+    const watchdog = window.setInterval(() => {
+      if (!recovering && engine.isContextLost()) {
+        handleContextLoss();
+      }
+    }, CONTEXT_WATCHDOG_MS);
+
     return () => {
+      window.clearInterval(watchdog);
+      detachContextLoss();
       canvas.removeEventListener("pointerdown", onDown);
       canvas.removeEventListener("pointermove", onMove);
       canvas.removeEventListener("pointerup", onUp);

--- a/src/windows/annotation/overlayGpuGuard.selfcheck.ts
+++ b/src/windows/annotation/overlayGpuGuard.selfcheck.ts
@@ -1,0 +1,76 @@
+/** Selfcheck: annotation overlay GPU-loss policy + 2D context-loss listeners. */
+import {
+  attachCanvas2dContextLoss,
+  planOverlayRecovery,
+} from "./overlayGpuGuard.ts";
+import { MAX_RECOVER_ATTEMPTS, RECOVER_WINDOW_MS } from "../editor/render/gpuLifecycle.ts";
+
+function assert(cond: unknown, msg: string): asserts cond {
+  if (!cond) throw new Error(msg);
+}
+
+// A first loss recovers: the overlay hides, rebuilds, and comes back.
+const first = planOverlayRecovery({ attempts: 0, lastAttemptAtMs: null }, 1_000);
+assert(first.action === "recover", "first loss recovers");
+assert(first.next.attempts === 1, "the loss is counted");
+assert(first.next.lastAttemptAtMs === 1_000, "and stamped");
+
+// Repeated losses eventually stop re-showing. Re-showing into a dead GPU is
+// what would flicker the whole desktop black over and over.
+let state = { attempts: 0, lastAttemptAtMs: null as number | null };
+let now = 1_000;
+for (let i = 0; i < MAX_RECOVER_ATTEMPTS; i++) {
+  const step = planOverlayRecovery(state, now);
+  assert(step.action === "recover", `attempt ${i + 1} still recovers`);
+  state = step.next;
+  now += 1_000;
+}
+assert(
+  planOverlayRecovery(state, now).action === "stayHidden",
+  "past the cap the overlay stays hidden instead of blacking the screen again",
+);
+
+// Losses far enough apart are unrelated incidents, so a user who hits one bad
+// moment an hour into a session is not locked out of live ink.
+const laterOn = planOverlayRecovery(
+  { attempts: MAX_RECOVER_ATTEMPTS, lastAttemptAtMs: 0 },
+  RECOVER_WINDOW_MS + 1,
+);
+assert(laterOn.action === "recover", "a stale streak does not count against a fresh loss");
+
+// The listener must call preventDefault, or the engine may never restore the
+// context, and it must use the 2D event names rather than the WebGL ones.
+let prevented = false;
+let lost = 0;
+let restored = 0;
+const listeners = new Map<string, (e: Event) => void>();
+const fakeCanvas: EventTarget = {
+  addEventListener: (type: string, fn: EventListenerOrEventListenerObject) =>
+    listeners.set(type, fn as (e: Event) => void),
+  removeEventListener: (type: string) => listeners.delete(type),
+  dispatchEvent: () => true,
+};
+
+const detach = attachCanvas2dContextLoss(fakeCanvas, {
+  onLost: () => (lost += 1),
+  onRestored: () => (restored += 1),
+});
+assert(listeners.has("contextlost"), "listens for the canvas 2D loss event");
+assert(
+  !listeners.has("webglcontextlost"),
+  "must not listen for the WebGL event name — a 2D canvas never fires it",
+);
+
+listeners.get("contextlost")!({
+  preventDefault: () => (prevented = true),
+} as unknown as Event);
+assert(prevented, "loss is preventDefault-ed so the context may be restored");
+assert(lost === 1, "loss reaches the handler");
+
+listeners.get("contextrestored")!({} as Event);
+assert(restored === 1, "restore reaches the handler");
+
+detach();
+assert(listeners.size === 0, "detach removes both listeners");
+
+console.log("overlayGpuGuard.selfcheck: ok");

--- a/src/windows/annotation/overlayGpuGuard.ts
+++ b/src/windows/annotation/overlayGpuGuard.ts
@@ -1,0 +1,87 @@
+/**
+ * Keeps a lost GPU context from blanking the user's desktop (#25).
+ *
+ * The annotation overlay is a fullscreen, transparent, always-on-top WebView2
+ * window. That combination is fine until WebView2's GPU context resets — the
+ * surface then composites *opaque*, and because the window covers the whole
+ * screen and sits above everything, the entire desktop goes black in the middle
+ * of a recording. Nothing recovers it, because nothing was watching.
+ *
+ * The important move on a loss is therefore not "repaint the ink". It is **stop
+ * covering the screen**: a hidden window cannot paint black over anything. Ink
+ * is safe regardless — `AnnotationEngine` keeps strokes as history data, not as
+ * pixels, so a rebuilt context repaints them exactly.
+ *
+ * Recovery is bounded by the editor's existing policy (`decideRecovery`). If the
+ * GPU keeps dying, the overlay stays hidden rather than flickering the desktop
+ * black on every attempt — a recording without live ink beats a recording of a
+ * black screen, and the user still has their content.
+ *
+ * Pure on purpose: selfchecks run under plain Node with no Vite aliases and no
+ * DOM, so the policy is separated from the DOM plumbing that uses it.
+ */
+
+import { decideRecovery } from "../editor/render/gpuLifecycle.ts";
+
+/** What the overlay should do after its drawing context died. */
+export type OverlayGpuAction =
+  /** Rebuild the context and show the overlay again. */
+  | "recover"
+  /** Lost too often — leave the overlay hidden for the rest of the session. */
+  | "stayHidden";
+
+export interface OverlayRecoveryState {
+  /** Losses handled so far inside the current window. */
+  attempts: number;
+  /** When the last one was handled, or `null` if this is the first. */
+  lastAttemptAtMs: number | null;
+}
+
+/**
+ * Decide what to do about one context loss.
+ *
+ * Delegates the "how many times, how recently" question to the editor's
+ * `decideRecovery` so both windows give up on the same terms; losses spread far
+ * enough apart are unrelated incidents and reset the counter there.
+ */
+export function planOverlayRecovery(
+  state: OverlayRecoveryState,
+  nowMs: number,
+): { action: OverlayGpuAction; next: OverlayRecoveryState } {
+  const { decision, nextAttempts } = decideRecovery({
+    attempts: state.attempts,
+    lastAttemptAtMs: state.lastAttemptAtMs,
+    nowMs,
+  });
+  return {
+    action: decision === "retry" ? "recover" : "stayHidden",
+    next: { attempts: nextAttempts, lastAttemptAtMs: nowMs },
+  };
+}
+
+/**
+ * Attach canvas 2D context-loss listeners.
+ *
+ * Note these are `contextlost` / `contextrestored` — *not* the `webglcontext*`
+ * pair the editor uses. The overlay draws with a 2D context, which fires its
+ * own events; listening for the WebGL names here would silently never fire.
+ *
+ * `preventDefault()` on loss is what tells the engine it may restore the
+ * context rather than abandoning it for good.
+ */
+export function attachCanvas2dContextLoss(
+  canvas: EventTarget,
+  handlers: { onLost: () => void; onRestored: () => void },
+): () => void {
+  const handleLost = (event: Event) => {
+    event.preventDefault();
+    handlers.onLost();
+  };
+  const handleRestored = () => handlers.onRestored();
+  canvas.addEventListener("contextlost", handleLost);
+  canvas.addEventListener("contextrestored", handleRestored);
+  return () => {
+    canvas.removeEventListener("contextlost", handleLost);
+    canvas.removeEventListener("contextrestored", handleRestored);
+  };
+}


### PR DESCRIPTION
Fixes #25

On Windows, drawing with the annotation tools would randomly turn the whole screen black mid-recording. The reporter confirms it goes completely black (not white, not frozen stale content).

### Cause

The annotation overlay is a fullscreen, transparent, always-on-top WebView2 window drawing to a canvas 2D context. That is fine until WebView2's GPU context resets: the surface then composites *opaque*, and because the window covers the entire screen and sits above everything, the desktop goes black. Nothing recovered it, because nothing was watching.

`gpuLifecycle` exists for exactly this hazard but only the editor ever used it, and `webview_gpu.rs` exists only because this GPU path is known to be fragile. #26 reports the same underlying fault from the other side ("Graphics Reset...").

### Approach

The important move on a loss is not repainting the ink, it is to **stop covering the screen** — a hidden window cannot paint black over anything. So the overlay hides first and sorts itself out afterwards. Ink survives regardless: `AnnotationEngine` keeps strokes as history data rather than pixels, so a rebuilt context repaints them exactly.

Recovery reuses the editor's `decideRecovery` policy so both windows give up on the same terms. Past the cap the overlay stays hidden instead of flickering the desktop black on every attempt — a take without live ink beats a take of a black screen, and the user keeps their content. It also refuses to come back while the context still reports lost, and never re-shows an overlay the user had already closed.

Two detection paths, because the window whose surface has gone black is exactly the window that stopped telling us things:

- The canvas 2D `contextlost` event is the fast path. Note that is `contextlost`, **not** the `webglcontextlost` the editor listens for — a 2D canvas never fires the WebGL name, so copying the editor's handler verbatim would silently never fire. The selfcheck pins this.
- A 2s watchdog polling `isContextLost()` covers a compositor fault that never dispatches the event.

### Verification

`overlayGpuGuard.selfcheck.ts` covers the retry cap, the stale-streak reset, `preventDefault` on loss, and the event-name trap. 46 selfchecks pass; `pnpm typecheck`, `pnpm lint` (identical problem count to `main`), and `pnpm build` are clean. The annotation bundle stays at ~35 kB, so the shared `gpuLifecycle` import tree-shakes rather than dragging editor/Pixi code in.

### Limits

I could not trigger a real WebView2 GPU reset on demand, so this is verified by construction and unit tests, not by watching a black screen recover. A reporter hitting it again should now find `annotation-overlay: 2D context lost (attempt N)` in `errors.log` — that line appearing is the confirmation, and its absence would mean the fault does not surface through the canvas at all.

Stated plainly: a compositor fault that leaves the canvas context reporting *healthy* would still go undetected. Escape already tears the overlay down by hand, which remains the backstop.

I also considered setting an explicit transparent `background_color` (Tauri 2.11 exposes it) and deliberately did not: wry already sets WebView2's default background transparent for `transparent(true)` windows, and WebView2's opaque default is *white*, not black, so it does not match the symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

