### PR TITLE
fix(recorder): say when the camera flush times out before stop

### DIFF
--- a/src/windows/recorder/flushCamera.ts
+++ b/src/windows/recorder/flushCamera.ts
@@ -3,26 +3,45 @@
 import { listen } from "@tauri-apps/api/event";
 import { commands } from "@/ipc/bindings";
 
-export async function flushCameraCaptureWithTimeout(ms = 4000): Promise<void> {
+/**
+ * Whether the bubble confirmed its flush, or the wait ran out.
+ *
+ * The distinction matters: `stop_recording` drops the camera sink as soon as it
+ * runs, so any MediaRecorder chunk still in flight afterwards is rejected with
+ * "no open camera file" and the WebM keeps whatever tail it had. `is_usable`
+ * only checks that the file is bigger than 2 KB, so a truncated capture is
+ * still handed to the editor, where it plays as no face-cam at all (#22).
+ *
+ * That used to happen silently. Returning the outcome lets the caller say so.
+ */
+export type CameraFlushOutcome = "flushed" | "timed-out";
+
+export async function flushCameraCaptureWithTimeout(
+  ms = 4000,
+): Promise<CameraFlushOutcome> {
   let unlisten: (() => void) | undefined;
   try {
-    await new Promise<void>((resolve) => {
+    return await new Promise<CameraFlushOutcome>((resolve) => {
       let settled = false;
-      const finish = () => {
+      const finish = (outcome: CameraFlushOutcome) => {
         if (settled) return;
         settled = true;
         window.clearTimeout(timer);
-        resolve();
+        resolve(outcome);
       };
-      const timer = window.setTimeout(finish, ms);
-      void listen("camera://capture-flushed", finish).then((un) => {
-        unlisten = un;
-        if (settled) {
-          un();
-          return;
-        }
-        void commands.flushCameraCapture().catch(finish);
-      });
+      const timer = window.setTimeout(() => finish("timed-out"), ms);
+      void listen("camera://capture-flushed", () => finish("flushed")).then(
+        (un) => {
+          unlisten = un;
+          if (settled) {
+            un();
+            return;
+          }
+          // A failed invoke is not a flush — the bubble never confirmed, so the
+          // tail of the capture is exactly as at risk as a timeout.
+          void commands.flushCameraCapture().catch(() => finish("timed-out"));
+        },
+      );
     });
   } finally {
     unlisten?.();

--- a/src/windows/recorder/store.ts
+++ b/src/windows/recorder/store.ts
@@ -773,7 +773,19 @@ export const useRecorderStore = create<RecorderStore>((set, get) => {
     const { cameraEnabled } = get();
     try {
       if (cameraEnabled) {
-        await flushCameraCaptureWithTimeout();
+        // A timeout here is not cosmetic: `stop_recording` drops the camera
+        // sink immediately after, so whatever the bubble had not written yet
+        // is lost and the face-cam can come back truncated or missing (#22).
+        // It cannot be recovered from at this point, but it must not vanish
+        // without a trace the way it used to.
+        if ((await flushCameraCaptureWithTimeout()) === "timed-out") {
+          logClientError(
+            "recorder",
+            new Error(
+              "camera flush timed out before stop; the face-cam track may be truncated",
+            ),
+          );
+        }
       }
       // Rust stops ScreenCaptureKit first, then opens the editor (so the blank
       // editor shell is never in the last frames), then finishes mux/finalize.


### PR DESCRIPTION
Refs #22

**This is not a fix.** It makes the moment the face-cam can be lost leave a trace, so the next report is diagnosable instead of a guess. Opening it separately for that reason — please leave #22 open when merging.

### What I found

Stopping a take with the camera on waits up to 4s for the bubble to flush its MediaRecorder tail, then calls `stop_recording` regardless. `stop_recording` drops the camera sink immediately (`state.camera_sink.lock().take()`), so any chunk still in flight afterwards is rejected with "no open camera file" and the WebM keeps whatever tail it had.

`camera_track::is_usable` only asks whether the file is larger than 2 KB, so a truncated capture still passes, still gets offered to the editor by `resolve`, and plays as no face-cam at all.

The 4s wait is most likely to expire exactly when the machine is already struggling — camera plus microphone on a 4K take, which is the load #26 reports. So the face-cam goes missing precisely in the case the user is least able to explain, and until now it did so without logging anything.

### Change

The flush helper returns whether the bubble confirmed or the wait ran out (a failed invoke counts as "not confirmed" — the tail is just as much at risk), and the caller logs a timeout. A future report of a missing face-cam should carry `camera flush timed out before stop` in `errors.log`, which turns a guess into a fact.

### Why not the real fix here

The real fix is for `stop_recording` not to discard a sink the bubble is still writing to. That is a change to the stop path — where a recording is finally committed to disk — and it deserves a reproduction in hand rather than a change made on inference. Two directions worth considering, for whoever picks it up:

- Have `stop_recording` await the flush rather than racing it, with the timeout as a bound instead of a silent fallthrough.
- Make `is_usable` validate the container rather than the byte count, so a truncated WebM is detected instead of handed to the editor as if it were fine.

`pnpm typecheck`, `pnpm lint` (identical problem count to `main`), 46 selfchecks, and `pnpm build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

