### PR TITLE
fix(recorder): keep captures inside the hardware H.264 encoder's 4096 px edge

### DIFF
--- a/src-tauri/src/export_rawvideo.rs
+++ b/src-tauri/src/export_rawvideo.rs
@@ -52,7 +52,7 @@ impl RawvideoStreamEncoder {
         }
 
         let ffmpeg = ffmpeg_path();
-        let encoder = hw_encoder::pick(&ffmpeg);
+        let encoder = hw_encoder::pick_for(&ffmpeg, width, height);
         let fps = fps.max(1);
         let bitrate = bitrate.max(500_000);
         let size = format!("{width}x{height}");

--- a/src-tauri/src/recorder/backend/mod.rs
+++ b/src-tauri/src/recorder/backend/mod.rs
@@ -137,6 +137,11 @@ pub struct CaptureHandle {
     /// capture: the frames are the *phone's* screen, so sampling the Mac cursor
     /// would write a cursor track that has nothing to do with the video.
     pub tracks_cursor: bool,
+    /// Something the user should know about this take that is not an error —
+    /// today: the capture was scaled on the GPU because the hardware encoder
+    /// would not take it at its native size. The controller surfaces it as a
+    /// non-fatal `RecorderEvent::Error`, which the recorder shows as a toast.
+    pub notice: Option<String>,
     /// The `Instant` that frame timestamps are measured from. The controller
     /// starts the cursor sampler on this same instant, which is what keeps the
     /// replayed cursor glued to the pixels it was recorded over — any epoch
@@ -171,6 +176,7 @@ impl CaptureHandle {
                 height: height as f64,
             },
             tracks_cursor: true,
+            notice: None,
             scale_factor: 1.0,
             // Handle construction happens as the producer comes up; backends
             // whose source clock can be anchored precisely overwrite this.

--- a/src-tauri/src/recorder/backend/scap_backend.rs
+++ b/src-tauri/src/recorder/backend/scap_backend.rs
@@ -17,10 +17,11 @@ use super::picker_sources;
 use super::source_preview;
 use super::{CaptureBackend, CaptureHandle, RawFrame, CAPTURE_CHANNEL_CAP};
 use crate::error::{AppError, AppResult};
-use crate::recorder::types::{CaptureSource, CaptureSourceKind, RecorderConfig};
+use crate::recorder::hw_encoder;
+use crate::recorder::types::{CaptureCrop, CaptureSource, CaptureSourceKind, RecorderConfig};
 use crate::windows;
 use core_graphics::display::CGDisplay;
-use scap::capturer::{Area, Capturer, Options, Point, Size};
+use scap::capturer::{Area, Capturer, Options, Point, Resolution, Size};
 use scap::frame::{Frame, FrameType};
 use scap::Target;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -130,6 +131,15 @@ impl CaptureBackend for ScapBackend {
         } else {
             windows::overlay_cgwindow_ids(&self.app)
         };
+        // A display or area wider than the hardware encoder takes is scaled by
+        // SCK on the GPU (see `hw_encoder::HW_ENCODER_EDGE`). scap only offers
+        // preset output sizes, so this picks the largest one that lands inside
+        // the edge; the window path sizes its own stream in `sck_window`.
+        let output_resolution = if is_window {
+            Resolution::Captured
+        } else {
+            display_output_resolution(&source_id, crop)
+        };
 
         let (tx, rx) = crossbeam_channel::bounded::<RawFrame>(CAPTURE_CHANNEL_CAP);
         let (meta_tx, meta_rx) =
@@ -188,6 +198,7 @@ impl CaptureBackend for ScapBackend {
                     fps,
                     show_cursor: false,
                     output_type: FrameType::BGRAFrame,
+                    output_resolution,
                     target: Some(target),
                     crop_area,
                     excluded_targets,
@@ -303,6 +314,10 @@ impl CaptureBackend for ScapBackend {
                     if scale_base > 0.0 {
                         handle.scale_factor = width as f64 / scale_base;
                     }
+                    let scale = picker_sources::display_scale_factor(id);
+                    let native =
+                        picker_sources::points_to_even_pixels(rect.width, rect.height, scale);
+                    handle.notice = hw_encoder::scaled_capture_notice(native, (width, height));
                 }
             }
             Some(("window", id_str)) => {
@@ -317,6 +332,10 @@ impl CaptureBackend for ScapBackend {
                     if rect.width > 0.0 {
                         handle.scale_factor = width as f64 / rect.width;
                     }
+                    let scale = display_scale_for_rect(&rect);
+                    let native =
+                        picker_sources::points_to_even_pixels(rect.width, rect.height, scale);
+                    handle.notice = hw_encoder::scaled_capture_notice(native, (width, height));
                     handle.capture_rect = rect;
                 }
             }
@@ -333,6 +352,96 @@ fn start_scap_capturer(options: Options) -> AppResult<(Capturer, [u32; 2])> {
     capturer.start_capture();
     let size = capturer.get_output_frame_size();
     Ok((capturer, size))
+}
+
+/// Backing scale of the display under a window frame's centre — the scale
+/// `sck_window` sized the stream with, recovered from Core Graphics so the
+/// notice can name the window's native pixel size. Falls back to the main
+/// display, like `sck_window` does when no display intersects the frame.
+fn display_scale_for_rect(rect: &crate::cursor::CaptureRect) -> u32 {
+    let cx = rect.x + rect.width / 2.0;
+    let cy = rect.y + rect.height / 2.0;
+    let id = CGDisplay::active_displays()
+        .ok()
+        .and_then(|ids| {
+            ids.into_iter().find(|&id| {
+                let b = CGDisplay::new(id).bounds();
+                cx >= b.origin.x
+                    && cx < b.origin.x + b.size.width
+                    && cy >= b.origin.y
+                    && cy < b.origin.y + b.size.height
+            })
+        })
+        .unwrap_or_else(|| CGDisplay::main().id);
+    picker_sources::display_scale_factor(id)
+}
+
+/// The scap output preset for a display (or area) capture: `Captured` when
+/// the backing-store size fits `hw_encoder::HW_ENCODER_EDGE`, otherwise the
+/// largest preset that lands inside the edge on both axes. scap resolves a
+/// preset to `[W, W / aspect]` and clamps each axis to the captured size, so
+/// the aspect ratio survives and the GPU does the scaling.
+fn display_output_resolution(source_id: &str, crop: Option<CaptureCrop>) -> Resolution {
+    let Some(("display", id_str)) = source_id.split_once(':') else {
+        return Resolution::Captured;
+    };
+    let Ok(display_id) = id_str.parse::<u32>() else {
+        return Resolution::Captured;
+    };
+    let bounds = CGDisplay::new(display_id).bounds();
+    let (width_pts, height_pts) = match crop {
+        Some(c) => (c.width, c.height),
+        None => (bounds.size.width, bounds.size.height),
+    };
+    let scale = picker_sources::display_scale_factor(display_id);
+    let (width, height) = picker_sources::points_to_even_pixels(width_pts, height_pts, scale);
+    let resolution = preset_inside_hardware_edge(width, height);
+    if !matches!(resolution, Resolution::Captured) {
+        tracing::info!(
+            source_id,
+            width,
+            height,
+            ?resolution,
+            "capture exceeds the hardware encoder edge; scaling on the GPU"
+        );
+    }
+    resolution
+}
+
+/// scap's preset ladder, widest first, with the width each preset resolves
+/// to. Mirrors `scap::capturer::Resolution::value` (0.0.8, pinned in
+/// Cargo.toml): `[W, floor(W / aspect)]`, then per-axis `min` with the
+/// captured size, then rounded down to even.
+const SCAP_PRESETS: &[(Resolution, u32)] = &[
+    (Resolution::_4320p, 7680),
+    (Resolution::_2160p, 3840),
+    (Resolution::_1440p, 2560),
+    (Resolution::_1080p, 1920),
+    (Resolution::_720p, 1280),
+    (Resolution::_480p, 640),
+];
+
+/// What scap will hand out for `width`×`height` under `preset` — the clamp
+/// from `get_output_frame_size`, reproduced so the pick can be checked against
+/// the edge before the stream exists.
+fn scap_output_size(width: u32, height: u32, preset_width: u32) -> (u32, u32) {
+    let aspect = width as f32 / height as f32;
+    let w = width.min(preset_width);
+    let h = height.min((preset_width as f32 / aspect).floor() as u32);
+    (w & !1, h & !1)
+}
+
+fn preset_inside_hardware_edge(width: u32, height: u32) -> Resolution {
+    if width.max(height) <= hw_encoder::HW_ENCODER_EDGE || width == 0 || height == 0 {
+        return Resolution::Captured;
+    }
+    for &(preset, preset_width) in SCAP_PRESETS {
+        let (w, h) = scap_output_size(width, height, preset_width);
+        if w.max(h) <= hw_encoder::HW_ENCODER_EDGE {
+            return preset;
+        }
+    }
+    Resolution::_480p
 }
 
 fn parse_source_id(source_id: &str) -> AppResult<u32> {
@@ -450,4 +559,72 @@ fn to_raw_frame(frame: Frame, epoch_host_ns: u64, epoch: Instant) -> Option<RawF
         data: f.data,
         timestamp,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn same(a: Resolution, b: Resolution) -> bool {
+        std::mem::discriminant(&a) == std::mem::discriminant(&b)
+    }
+
+    fn preset_width(preset: Resolution) -> u32 {
+        SCAP_PRESETS
+            .iter()
+            .find(|(p, _)| same(*p, preset))
+            .map(|(_, w)| *w)
+            .expect("every non-Captured preset is in the ladder")
+    }
+
+    #[test]
+    fn captures_inside_the_edge_keep_their_size() {
+        assert!(same(preset_inside_hardware_edge(3840, 2160), Resolution::Captured));
+        assert!(same(preset_inside_hardware_edge(4096, 2304), Resolution::Captured));
+        assert!(same(preset_inside_hardware_edge(0, 9000), Resolution::Captured));
+    }
+
+    #[test]
+    fn a_5k_display_lands_on_the_2160p_preset() {
+        // 2560×1440 pt at 2× — scap resolves _2160p to [3840, 2160] here.
+        assert!(same(preset_inside_hardware_edge(5120, 2880), Resolution::_2160p));
+        assert_eq!(scap_output_size(5120, 2880, 3840), (3840, 2160));
+        // An area of that display, 2560×1410 pt.
+        assert!(same(preset_inside_hardware_edge(5120, 2820), Resolution::_2160p));
+        assert_eq!(scap_output_size(5120, 2820, 3840), (3840, 2114));
+    }
+
+    #[test]
+    fn a_portrait_5k_display_needs_a_smaller_preset() {
+        // _2160p resolves to [3840, 6826] and the per-axis min keeps the
+        // captured 5120 px height — only _1080p gets both axes under the edge.
+        assert!(same(preset_inside_hardware_edge(2880, 5120), Resolution::_1080p));
+        assert_eq!(scap_output_size(2880, 5120, 1920), (1920, 3412));
+    }
+
+    #[test]
+    fn every_oversize_pick_fits_the_edge_under_scaps_clamp() {
+        for (w, h) in [
+            (5120, 2880),
+            (5120, 2820),
+            (2880, 5120),
+            (10240, 4320),
+            (6016, 3384),
+            (4100, 4100),
+            (7680, 2160),
+        ] {
+            let preset = preset_inside_hardware_edge(w, h);
+            let (ow, oh) = scap_output_size(w, h, preset_width(preset));
+            assert!(
+                ow.max(oh) <= hw_encoder::HW_ENCODER_EDGE,
+                "{w}x{h} → {preset:?} → {ow}x{oh}"
+            );
+            let aspect_in = w as f64 / h as f64;
+            let aspect_out = ow as f64 / oh as f64;
+            assert!(
+                ((aspect_in - aspect_out) / aspect_in).abs() < 0.01,
+                "{w}x{h} → {preset:?} → {ow}x{oh} changes the aspect ratio"
+            );
+        }
+    }
 }

--- a/src-tauri/src/recorder/backend/sck_window.rs
+++ b/src-tauri/src/recorder/backend/sck_window.rs
@@ -8,6 +8,7 @@ use super::picker_sources;
 use super::RawFrame;
 use crate::cursor::CaptureRect;
 use crate::error::{AppError, AppResult};
+use crate::recorder::hw_encoder;
 use crossbeam_channel::{Sender, TrySendError};
 use objc::{msg_send, sel, sel_impl};
 use objc_id::Id;
@@ -159,13 +160,30 @@ fn run_window_capture_inner(
         })?;
 
     let displays = content.displays();
-    let (cfg_w, cfg_h) = stream_config_pixels(&window, &displays);
+    let native = stream_config_pixels(&window, &displays);
+    // A window wider than the hardware encoder takes is scaled by SCK on the
+    // GPU rather than encoded in software at full size (see
+    // `hw_encoder::HW_ENCODER_EDGE`). `scales_to_fit` is what makes SCK honour
+    // a size other than the window's own; the target keeps the window's aspect
+    // ratio, so nothing is letterboxed.
+    let scaled = hw_encoder::fit_to_hardware_edge(native.0, native.1);
+    let (cfg_w, cfg_h) = scaled.unwrap_or(native);
+    if let Some((w, h)) = scaled {
+        tracing::info!(
+            window_id,
+            native_width = native.0,
+            native_height = native.1,
+            width = w,
+            height = h,
+            "window exceeds the hardware encoder edge; scaling on the GPU"
+        );
+    }
     let filter = UnsafeContentFilter::init(UnsafeInitParams::DesktopIndependentWindow(window));
 
     let config = UnsafeStreamConfiguration {
         width: cfg_w,
         height: cfg_h,
-        scales_to_fit: 0,
+        scales_to_fit: BOOL::from(scaled.is_some()),
         queue_depth: 6,
         shows_cursor: 0,
         minimum_frame_interval: CMTime {

--- a/src-tauri/src/recorder/encoder.rs
+++ b/src-tauri/src/recorder/encoder.rs
@@ -52,6 +52,9 @@ pub struct Encoder {
     height: u32,
     frame_len: usize,
     output: PathBuf,
+    /// Set when `hw_encoder::pick_for` demoted the startup pick for this frame
+    /// size: `(refused hardware encoder, software encoder in use)`.
+    demoted: Option<(&'static str, &'static str)>,
 }
 
 impl Encoder {
@@ -66,7 +69,9 @@ impl Encoder {
     ) -> AppResult<Self> {
         let bitrate = quality.target_bitrate(width, height);
         let ffmpeg = ffmpeg_path();
-        let encoder = hw_encoder::pick(&ffmpeg);
+        let encoder = hw_encoder::pick_for(&ffmpeg, width, height);
+        let startup = hw_encoder::pick(&ffmpeg);
+        let demoted = (startup.name != encoder.name).then_some((startup.name, encoder.name));
 
         let mut child = proc::command(&ffmpeg)
             .args(["-hide_banner", "-loglevel", "error", "-y"])
@@ -168,6 +173,15 @@ impl Encoder {
             height,
             frame_len: (width as usize) * (height as usize) * 4,
             output: output.to_path_buf(),
+            demoted,
+        })
+    }
+
+    /// The user-facing note for a take that lost its hardware encoder to the
+    /// frame size, or `None` when the startup pick is in use.
+    pub fn software_fallback_notice(&self) -> Option<String> {
+        self.demoted.map(|(refused, fallback)| {
+            hw_encoder::software_fallback_notice(self.width, self.height, refused, fallback)
         })
     }
 

--- a/src-tauri/src/recorder/hw_encoder.rs
+++ b/src-tauri/src/recorder/hw_encoder.rs
@@ -3,11 +3,17 @@
 //! choice is *probed* once per process (a 2-frame smoke encode against the null
 //! muxer, ~100 ms) and cached. Every FFmpeg pipeline that encodes H.264
 //! (recorder, preview proxy) consumes the same [`EncoderChoice`].
+//!
+//! The startup probe runs at 256×144, which says nothing about frames a
+//! hardware encoder caps below the capture size. Callers that know their frame
+//! size go through [`pick_for`], which re-probes the pick at the exact size
+//! once it exceeds what the startup probe covers.
 
 use crate::proc;
+use std::collections::HashMap;
 use std::path::Path;
 use std::process::Stdio;
-use std::sync::OnceLock;
+use std::sync::{Mutex, OnceLock};
 
 /// One FFmpeg H.264 encoder plus the arg plumbing it needs. Fields are ordered
 /// the way they appear on the command line:
@@ -114,6 +120,19 @@ const SOFTWARE_FALLBACK: EncoderChoice = EncoderChoice {
     tuning_args: &["-preset", "veryfast"],
 };
 
+/// The software fallback as handed out for frames a hardware encoder refused.
+///
+/// `veryfast` — the regular fallback — measured 1.24× realtime for 5120×2820
+/// at 60 fps on an M4, reading BGRA from a file with nothing else running. The
+/// recorder adds a 57 MB frame copy and a pipe write per frame on top of that,
+/// and in a real 51 s take it shed close to half the captured frames.
+/// `ultrafast` measured 2.34× on the same input. Frames this size get ~28 Mbps,
+/// where the preset's quality cost does not show; the dropped frames do.
+const OVERSIZE_SOFTWARE_FALLBACK: EncoderChoice = EncoderChoice {
+    tuning_args: &["-preset", "ultrafast"],
+    ..SOFTWARE_FALLBACK
+};
+
 /// Candidates in preference order per OS. The last entry must be the software
 /// fallback so `pick()` can always return something.
 fn candidates() -> &'static [EncoderChoice] {
@@ -190,6 +209,118 @@ fn candidates() -> &'static [EncoderChoice] {
 pub fn pick(ffmpeg: &Path) -> &'static EncoderChoice {
     static PICK: OnceLock<EncoderChoice> = OnceLock::new();
     PICK.get_or_init(|| select(ffmpeg))
+}
+
+/// The largest frame edge every hardware H.264 encoder in the candidate list
+/// is known to accept: H.264 Level 5.1/5.2 tops out at 4096 px per edge.
+///
+/// Larger frames are ordinary on HiDPI displays — a 2560×1440-pt screen
+/// captures at 5120×2880 px — and VideoToolbox answers them with `Cannot
+/// create compression session: -12903` on the first real frame, long after
+/// the 256×144 startup probe blessed it. The recorder then saw ffmpeg die, hit
+/// a broken pipe and shelved a 0-byte take.
+///
+/// Two layers keep captures inside this edge. Backends that can scale on the
+/// GPU ask for a stream that already fits ([`fit_to_hardware_edge`]), so the
+/// hardware encoder keeps the take. Whatever still arrives larger goes through
+/// [`pick_for`], which re-probes the pick at that size and demotes it to the
+/// software encoder instead of letting it die mid-take.
+pub const HW_ENCODER_EDGE: u32 = 4096;
+
+/// The even output size that fits a `width`×`height` capture inside
+/// [`HW_ENCODER_EDGE`] at the same aspect ratio, or `None` when it already
+/// fits. Backends hand this to the capture API so the scaling happens on the
+/// GPU before a frame is ever copied: encoding the full-size frame in software
+/// instead saturated an M4 (5120×2820 at 60 fps: ~47 % of captured frames
+/// dropped, the system-audio queue overflowing).
+pub fn fit_to_hardware_edge(width: u32, height: u32) -> Option<(u32, u32)> {
+    let edge = width.max(height);
+    if edge <= HW_ENCODER_EDGE || width == 0 || height == 0 {
+        return None;
+    }
+    let scale = HW_ENCODER_EDGE as f64 / edge as f64;
+    // Nearest even value: the encoder wants even dimensions, and SCK
+    // letterboxes whatever misses the source aspect, so stay as close to it
+    // as two-pixel steps allow. The long edge lands on the edge exactly.
+    let fit = |px: u32| ((px as f64 * scale / 2.0).round() as u32 * 2).max(2);
+    Some((fit(width), fit(height)))
+}
+
+/// What to tell the user when a capture was scaled from `native` down to
+/// `actual` to stay inside [`HW_ENCODER_EDGE`] — `None` when nothing was
+/// scaled. A silent downscale reads as "the recording is soft", and a silent
+/// failure (the 0-byte take this replaces) reads as "the app is broken"; the
+/// toast is the difference between the two.
+pub fn scaled_capture_notice(native: (u32, u32), actual: (u32, u32)) -> Option<String> {
+    if fit_to_hardware_edge(native.0, native.1).is_none() || actual == native {
+        return None;
+    }
+    Some(format!(
+        "Recording at {}×{} instead of {}×{}: the hardware encoder takes at most {} px per edge, so the capture is scaled on the GPU.",
+        actual.0, actual.1, native.0, native.1, HW_ENCODER_EDGE
+    ))
+}
+
+/// What to tell the user when the hardware encoder refused the frame size and
+/// the take runs on `fallback` instead (see [`pick_for`]).
+pub fn software_fallback_notice(
+    width: u32,
+    height: u32,
+    refused: &str,
+    fallback: &str,
+) -> String {
+    format!(
+        "{width}×{height} is more than the {refused} hardware encoder accepts; recording with the {fallback} software encoder instead, which costs CPU and may drop frames."
+    )
+}
+
+/// The encoder for frames of `width`×`height`: the cached [`pick`] for any
+/// size inside [`HW_ENCODER_EDGE`], otherwise that pick re-probed at the exact
+/// size and demoted to the software fallback if it refuses. Oversize answers
+/// are cached per size, so the probe (~0.1 s) runs once per size, not once per
+/// recording.
+pub fn pick_for(ffmpeg: &Path, width: u32, height: u32) -> EncoderChoice {
+    let chosen = *pick(ffmpeg);
+    if width.max(height) <= HW_ENCODER_EDGE {
+        return chosen;
+    }
+    static OVERSIZE: OnceLock<Mutex<HashMap<(u32, u32), EncoderChoice>>> = OnceLock::new();
+    let cache = OVERSIZE.get_or_init(|| Mutex::new(HashMap::new()));
+    if let Some(cached) = cache.lock().unwrap().get(&(width, height)) {
+        return *cached;
+    }
+    // Probe outside the lock: a recording and an export may ask concurrently,
+    // and a duplicate probe is cheaper than serialising them on a mutex.
+    let choice = select_for(ffmpeg, chosen, width, height);
+    cache.lock().unwrap().insert((width, height), choice);
+    choice
+}
+
+/// The oversize decision behind [`pick_for`], without the cache. Split out for
+/// the same reason as [`select`]: a test must not depend on who warmed the
+/// `OnceLock`.
+fn select_for(ffmpeg: &Path, chosen: EncoderChoice, width: u32, height: u32) -> EncoderChoice {
+    if chosen.name == SOFTWARE_FALLBACK.name {
+        // Nothing to demote to; libx264 handles Level 6 sizes on its own.
+        return chosen;
+    }
+    match probe_at(ffmpeg, &chosen, width, height) {
+        Ok(()) => chosen,
+        Err(failure) => {
+            // WARN, not INFO: this is the one place a hardware machine silently
+            // goes software, and "why is this 5K recording eating my CPU" must
+            // be answerable from the log.
+            tracing::warn!(
+                encoder = chosen.name,
+                width,
+                height,
+                fallback = OVERSIZE_SOFTWARE_FALLBACK.name,
+                reason = %failure,
+                "hardware encoder rejected the frame size; using the software encoder for it"
+            );
+            OVERSIZE_SOFTWARE_FALLBACK
+        }
+    }
 }
 
 /// The probe loop behind [`pick`], without the cache. Split out so the fallback
@@ -270,10 +401,22 @@ impl std::fmt::Display for ProbeFailure {
 /// Encode 2 synthetic frames to the null muxer. Cheap, and exercises the real
 /// encoder init path (driver present, session available).
 fn probe(ffmpeg: &Path, choice: &EncoderChoice) -> Result<(), ProbeFailure> {
+    probe_at(ffmpeg, choice, 256, 144)
+}
+
+/// [`probe`] at an explicit frame size — the session an encoder opens depends
+/// on it, and a rejection only shows up at the size that triggers it.
+fn probe_at(
+    ffmpeg: &Path,
+    choice: &EncoderChoice,
+    width: u32,
+    height: u32,
+) -> Result<(), ProbeFailure> {
     let mut cmd = proc::command(ffmpeg);
     cmd.args(["-hide_banner", "-loglevel", "error", "-nostdin"])
         .args(choice.pre_input_args)
-        .args(["-f", "lavfi", "-i", "color=black:s=256x144:r=30:d=0.1"])
+        .args(["-f", "lavfi", "-i"])
+        .arg(format!("color=black:s={width}x{height}:r=30:d=0.1"))
         .args(["-c:v", choice.name])
         .args(choice.output_args(None))
         .args(choice.tuning_args)
@@ -394,6 +537,118 @@ mod tests {
     fn selection_falls_back_to_software_when_all_probes_fail() {
         let choice = select(Path::new("/nonexistent/ffmpeg-for-test"));
         assert_eq!(choice.name, "libx264");
+    }
+
+    #[test]
+    fn frames_inside_the_edge_are_left_alone() {
+        assert_eq!(fit_to_hardware_edge(3840, 2160), None);
+        assert_eq!(fit_to_hardware_edge(4096, 2304), None);
+        assert_eq!(fit_to_hardware_edge(0, 5000), None);
+    }
+
+    #[test]
+    fn oversize_frames_scale_to_the_edge_at_the_same_aspect() {
+        // The incident: a 2560×1440-pt HiDPI display, 5120×2880 px.
+        assert_eq!(fit_to_hardware_edge(5120, 2880), Some((4096, 2304)));
+        // The window from the report, 2560×1410 pt.
+        assert_eq!(fit_to_hardware_edge(5120, 2820), Some((4096, 2256)));
+        // Portrait: the long edge is the height.
+        assert_eq!(fit_to_hardware_edge(2880, 5120), Some((2304, 4096)));
+    }
+
+    #[test]
+    fn scaled_sizes_are_even_and_never_exceed_the_edge() {
+        for (w, h) in [(4097, 2161), (5121, 2883), (9999, 333), (4100, 4100)] {
+            let (fw, fh) = fit_to_hardware_edge(w, h).expect("oversize");
+            assert_eq!(fw % 2, 0, "{w}x{h} → {fw}x{fh}");
+            assert_eq!(fh % 2, 0, "{w}x{h} → {fw}x{fh}");
+            assert!(
+                fw <= HW_ENCODER_EDGE && fh <= HW_ENCODER_EDGE,
+                "{w}x{h} → {fw}x{fh}"
+            );
+            let aspect_in = w as f64 / h as f64;
+            let aspect_out = fw as f64 / fh as f64;
+            assert!(
+                ((aspect_in - aspect_out) / aspect_in).abs() < 0.01,
+                "{w}x{h} → {fw}x{fh} changes the aspect ratio"
+            );
+        }
+    }
+
+    #[test]
+    fn no_notice_unless_something_was_scaled() {
+        assert_eq!(scaled_capture_notice((3840, 2160), (3840, 2160)), None);
+        assert_eq!(scaled_capture_notice((5120, 2880), (5120, 2880)), None);
+        // Inside the edge nothing is ever scaled for the encoder's sake, so a
+        // size mismatch there is not this notice's business.
+        assert_eq!(scaled_capture_notice((3840, 2160), (1920, 1080)), None);
+    }
+
+    #[test]
+    fn a_scaled_capture_names_both_sizes_and_the_edge() {
+        let notice = scaled_capture_notice((5120, 2820), (4096, 2256)).expect("scaled");
+        assert!(notice.contains("4096×2256"), "{notice}");
+        assert!(notice.contains("5120×2820"), "{notice}");
+        assert!(notice.contains("4096 px"), "{notice}");
+    }
+
+    #[test]
+    fn a_software_pick_is_never_reprobed() {
+        // There is nothing to demote libx264 to, so an oversize frame must not
+        // spawn ffmpeg at all — a missing binary proves it was never consulted.
+        let choice = select_for(
+            Path::new("/nonexistent/ffmpeg-for-test"),
+            SOFTWARE_FALLBACK,
+            5120,
+            2880,
+        );
+        assert_eq!(choice.name, "libx264");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn videotoolbox_is_demoted_above_its_4096_px_edge() {
+        // The incident behind `pick_for`: a 2560×1440-pt HiDPI display
+        // captures at 5120×2880 px, VideoToolbox's H.264 session refuses
+        // anything wider than 4096 px, and the startup probe cannot know.
+        let ffmpeg = crate::recorder::encoder::ffmpeg_path();
+        let chosen = select(&ffmpeg);
+        if chosen.name != "h264_videotoolbox" {
+            // No usable VideoToolbox here (no sidecar on this runner) — there
+            // is nothing to demote, so skip rather than assert on libx264.
+            return;
+        }
+        assert_eq!(
+            select_for(&ffmpeg, chosen, 3840, 2160).name,
+            "h264_videotoolbox",
+            "4K is inside the edge and must keep the hardware encoder"
+        );
+        let demoted = select_for(&ffmpeg, chosen, 5120, 2880);
+        assert_eq!(
+            demoted.name, "libx264",
+            "5K must fall back to software instead of dying on the first frame"
+        );
+        assert!(
+            demoted.tuning_args.contains(&"ultrafast"),
+            "the oversize fallback needs the headroom preset, got {:?}",
+            demoted.tuning_args
+        );
+    }
+
+    #[test]
+    fn oversize_fallback_only_differs_in_its_preset() {
+        // Same encoder, same pixel format, same plumbing — only the speed knob
+        // moves, so everything the recorder assumes about libx264 still holds.
+        assert_eq!(OVERSIZE_SOFTWARE_FALLBACK.name, SOFTWARE_FALLBACK.name);
+        assert_eq!(OVERSIZE_SOFTWARE_FALLBACK.pix_fmt, SOFTWARE_FALLBACK.pix_fmt);
+        assert_eq!(
+            OVERSIZE_SOFTWARE_FALLBACK.pre_input_args,
+            SOFTWARE_FALLBACK.pre_input_args
+        );
+        assert_eq!(
+            OVERSIZE_SOFTWARE_FALLBACK.tuning_args,
+            &["-preset", "ultrafast"]
+        );
     }
 
     #[test]

--- a/src-tauri/src/recorder/mod.rs
+++ b/src-tauri/src/recorder/mod.rs
@@ -134,6 +134,7 @@ impl RecorderController {
         // source errors surface, before we spawn anything.
         let capture: CaptureHandle = self.backend.start(config)?;
         let (width, height) = encodable_dimensions(capture.width, capture.height)?;
+        let mut notices: Vec<String> = capture.notice.iter().cloned().collect();
         let fps = capture.fps;
         let system_audio = capture.audio.is_some();
         let microphone = capture.mic.is_some();
@@ -148,6 +149,7 @@ impl RecorderController {
             system_audio,
             microphone,
         )?;
+        notices.extend(encoder.software_fallback_notice());
 
         // One clock for everything: frame timestamps are measured from the
         // backend's `epoch`, so the cursor sampler must stamp against that
@@ -197,6 +199,16 @@ impl RecorderController {
         });
         self.set_state(RecorderState::Recording);
         (self.emit)(RecorderEvent::Elapsed { seconds: 0.0 });
+        // Non-fatal: the recorder shows it as a toast and keeps the take going.
+        // Emitted after the state change so a listener that resets on
+        // `StateChanged` does not wipe it.
+        for message in notices {
+            tracing::info!(%message, "capture notice");
+            (self.emit)(RecorderEvent::Error {
+                message,
+                fatal: false,
+            });
+        }
         Ok(())
     }
 


### PR DESCRIPTION
## Symptom

On HiDPI displays whose framebuffer is wider than 4096 px, every recording of a full-screen window or of the whole display ends up as a 0-byte `screen.mp4`, shows up in the library with 0 s, and the timer never starts. Reproduced on macOS 26.6 with two 4K panels in the scaled "2560 × 1440" mode (= 5120 × 2880 px at 2×), Capptivo 1.0.0 and 1.0.3. Looks like the same bug as #33.

## Root cause

`hw_encoder::pick()` probes the H.264 encoder once per process with a 256 × 144 clip. VideoToolbox passes that probe, but its H.264 session takes at most 4096 px per edge (4096 × 2820 → ok, 4200 × 2820 → refused). The recorder only learns this on the first real frame:

```
WARN  encoder.finish failed; keeping partial file e=encoder failed: ffmpeg exited with exit status: 187: [h264_videotoolbox] Cannot create compression session: -12903
ERROR recording encode failed; partial take kept on disk e=encoder failed: write to ffmpeg failed: Broken pipe (os error 32) frames=1
```

ffmpeg dies before the `moov` atom, the writer hits a broken pipe, the SCK streams are torn down ~500 ms after start, and the empty take stays in the library. The rawvideo export path uses the same pick and fails the same way for 5K recordings.

## Fix, in two layers

1. **Scale on the GPU before a frame is ever copied (macOS).** `hw_encoder::HW_ENCODER_EDGE = 4096` and `fit_to_hardware_edge()` give the even target size at the source aspect ratio. The window path (`sck_window`) configures the `SCStream` with it and sets `scalesToFit`; the display/area path (scap) picks the largest preset whose result fits the edge on both axes (scap resolves `[W, W / aspect]` and clamps per axis, so the aspect ratio survives). The hardware encoder stays in the game. `scale_factor` on the `CaptureHandle` is already derived from frame width / point width and cursor samples are normalized, so cursor overlay and zoom keep lining up (5120 × 2820 → 4096 × 2256, `scaleFactor` 1.6, no letterbox according to `cropdetect`).

2. **Safety net for anything that still arrives larger (other backends, Windows/Linux).** `hw_encoder::pick_for(ffmpeg, w, h)` re-probes the cached pick once at the real size above the edge (`probe_at`) and demotes it to `libx264 -preset ultrafast` (`OVERSIZE_SOFTWARE_FALLBACK`) when refused, with a WARN carrying encoder, size and ffmpeg's reason; the answer is cached per size (VT refuses in ~75 ms). `Encoder::spawn` (recorder) and `export_rawvideo` use `pick_for`; the proxy (1280 px) and the face-cam track keep `pick()`. No hard-coded per-encoder limits — the same probe-don't-assume approach as the rest of the module.

3. **User notice.** When a take is scaled or demoted, the backend sets `CaptureHandle.notice` or `Encoder::software_fallback_notice()`, and the controller emits the text after start as a non-fatal `recorder://error`. With today's toast (6 s, only while the recorder bar is visible) it is easy to miss — see #47.

## Measurements (M4, bundled ffmpeg)

**VideoToolbox:** 4096 × 2820 ok; 4200 × 2820 and 5120 × 2820 → `-12903`.

**Software at 5120 × 2820 @ 60 fps inside the app:** `veryfast` 3067 frames / 2787 dropped (47.6 %) in 51 s, `ultrafast` 1341 / 1164 (46.5 %) in 22 s, system audio choppy. In isolation (BGRA from a file, 27.8 Mbps):

| encoder | speed |
| --- | --- |
| `libx264 -preset veryfast` | 1.24× |
| `libx264 -preset superfast` | 1.83× |
| `libx264 -preset ultrafast` | 2.34× |
| BGRA → yuv420p conversion only | 2.61× |
| `h264_videotoolbox` + `scale=4096:-2` | 0.9× |

**Hardware reference, 3022 × 2308 @ 60:** 4032 frames / 3 dropped.

**GPU-scaled 4096 × 2256 @ 60 with the hardware encoder:** 1717 / 1113 (39 %) in 28.6 s, 370 / 19 (5 %) in 6.2 s. The limit here is the BGRA pipe into ffmpeg, not the encoder — BGRA pipe → ffmpeg → VT without the app:

| size @ 60 fps | bandwidth | throughput |
| --- | --- | --- |
| 3022 × 2308 | 1.67 GB/s | 1.19× |
| 3840 × 2160 | 1.99 GB/s | 1.03× |
| 4096 × 2256 | 2.22 GB/s | 0.92× (pipe alone 1.62×) |

That is a pre-existing ceiling for 60 fps from roughly 4K upwards and independent of this PR; at 30 fps 4096 × 2256 sits at 1.1 GB/s (not measured). A follow-up that sends NV12 instead of BGRA through the pipe (1.5 instead of 4 bytes per pixel, SCK delivers it directly) would solve 4K60.

**Sharpness:** the same image region from the 4096 take (×1.25 up to screen scale) and from the 5120 take at 1:1 are visually indistinguishable; the editor preview (1280 px proxy) is clearly softer than both.

## Tests

157 passing. New: `fit_to_hardware_edge` (inside/outside the edge, even values, aspect ratio), the scap preset choice (5K → `_2160p`, portrait 5K → `_1080p`, every pick inside the edge under scap's clamp), `videotoolbox_is_demoted_above_its_4096_px_edge` (macOS, skips without VideoToolbox), a software pick is never re-probed, the oversize fallback differs only in its preset, notice texts.

## Manual verification

macOS 26.6, M4, two 2560 × 1440 pt @ 2×: a 2560 × 1410 pt window records as 4096 × 2256 with `h264_videotoolbox`, `scaleFactor` 1.6, finalizes cleanly, proxy and thumbnail are generated, the take opens in the editor. A 3022 × 2308 window still goes through the hardware path unchanged.

This should take care of #33 if the reporter is on a HiDPI display — the symptom matches exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UesofsbBT7iAtjVwoMVYoy
