### PR TITLE
Update selected-window capture and explain a narrow WGC device limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,11 @@ Platform notes:
 
 - **macOS** captures through native **ScreenCaptureKit** with **VideoToolbox** hardware
   H.264 encoding; system audio comes from a companion SCK stream.
-- **Windows** captures through native **Windows.Graphics.Capture**, with hardware
-  encoding probed per machine (NVENC / QuickSync / AMF / Media Foundation) and
-  system audio via **WASAPI loopback**.
+- **Windows** captures through native **Windows.Graphics.Capture**.
+  Capptivo's current Windows capture backend requires Direct3D feature level
+  11_0 or later on the hardware adapter Windows selects by default.
+  Hardware encoding is probed per machine (NVENC / QuickSync / AMF / Media
+  Foundation), with system audio via **WASAPI loopback**.
 - **Linux** captures through **xdg-desktop-portal + PipeWire** — the screen/window is
   picked in the system dialog. System audio comes from the PulseAudio/PipeWire
   monitor. Cursor replay / follow-zoom use an X11 pointer probe on X11 sessions,

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1034,7 +1034,7 @@ dependencies = [
  "ureq",
  "uuid",
  "windows 0.62.2",
- "windows-capture 2.0.0",
+ "windows-capture 2.0.1",
  "x11rb",
 ]
 
@@ -5846,9 +5846,9 @@ dependencies = [
 
 [[package]]
 name = "windows-capture"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9460c7b82f6b7d314d85b45610481f26a1159a42dadf1e13a329041553e060"
+checksum = "09046acbe9b6d039cde50e8c8178d95bb0f9b33ed7feccc4465dadc5404b31b4"
 dependencies = [
  "parking_lot",
  "rayon",

--- a/src-tauri/src/recorder/backend/wgc_backend.rs
+++ b/src-tauri/src/recorder/backend/wgc_backend.rs
@@ -25,7 +25,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use windows::Win32::Graphics::Gdi::HMONITOR;
-use windows_capture::capture::{Context, GraphicsCaptureApiHandler};
+use windows_capture::capture::{Context, GraphicsCaptureApiError, GraphicsCaptureApiHandler};
+use windows_capture::d3d11::Error as DirectXError;
 use windows_capture::frame::Frame;
 use windows_capture::graphics_capture_api::{GraphicsCaptureApi, InternalCaptureControl};
 use windows_capture::monitor::Monitor;
@@ -37,6 +38,21 @@ use windows_capture::window::Window;
 
 /// Sources smaller than this are noise (tooltips, hidden helpers), not targets.
 const MIN_WINDOW_SIDE: i32 = 96;
+
+fn map_wgc_start_error<E: std::fmt::Display>(error: GraphicsCaptureApiError<E>) -> AppError {
+    match error {
+        GraphicsCaptureApiError::DirectXError(DirectXError::FeatureLevelNotSatisfied) => {
+            AppError::Other(
+                "failed to start Windows capture: this capture backend requires Direct3D feature \
+                 level 11_0 or later on the hardware adapter Windows selects by default. The \
+                 selected adapter returned a lower level. Ensure a compatible graphics driver is \
+                 installed and enabled, or use compatible graphics hardware"
+                    .into(),
+            )
+        }
+        error => AppError::Other(format!("failed to start WGC capture: {error}")),
+    }
+}
 
 pub struct WgcBackend;
 
@@ -197,7 +213,7 @@ impl CaptureBackend for WgcBackend {
                 flags,
             )),
         }
-        .map_err(|e| AppError::Other(format!("failed to start WGC capture: {e}")))?;
+        .map_err(map_wgc_start_error)?;
 
         // First frame carries the exact output size (crop-adjusted) plus the
         // timestamp epoch the forwarder anchored at session start.
@@ -535,5 +551,37 @@ impl GraphicsCaptureApiHandler for FrameForwarder {
         // Captured window closed: dropping the sender disconnects the channel,
         // which ends the encode loop cleanly with whatever was recorded.
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn feature_level_failure_names_requirement_and_remediation() {
+        let error =
+            GraphicsCaptureApiError::<String>::DirectXError(DirectXError::FeatureLevelNotSatisfied);
+
+        assert_eq!(
+            map_wgc_start_error(error).to_string(),
+            "failed to start Windows capture: this capture backend requires Direct3D feature \
+             level 11_0 or later on the hardware adapter Windows selects by default. The selected \
+             adapter returned a lower level. Ensure a compatible graphics driver is installed and \
+             enabled, or use compatible graphics hardware"
+        );
+    }
+
+    #[test]
+    fn other_directx_failure_keeps_dependency_error() {
+        let error = GraphicsCaptureApiError::<String>::DirectXError(
+            DirectXError::UnexpectedNullResult("an ID3D11Device"),
+        );
+
+        assert_eq!(
+            map_wgc_start_error(error).to_string(),
+            "failed to start WGC capture: DirectX error: Windows API succeeded but did not return \
+             an ID3D11Device"
+        );
     }
 }


### PR DESCRIPTION
# Update selected-window capture and explain a narrow WGC device limit

Selected-window capture has a source-linked stale-frame repair and one narrow WGC device limit, as a multi-pass human-in-the-loop review with agentic coding traced
This combined branch updates the upstream capture dependency and limits the WGC message to its typed failure condition

## Contribution map

| Branch | Score | Why it matters | Pull request |
| --- | --- | --- | --- |
| [`fix/windows-crlf-cursor-hotspot-check`](https://github.com/Neonsy/capptivo/tree/fix/windows-crlf-cursor-hotspot-check) | 6/10 | Makes the cursor inventory stable across Windows and Unix line endings | [#59](https://github.com/SECHAK-AG/capptivo/pull/59) |
| [`chore/tooling-ci-release-baseline`](https://github.com/Neonsy/capptivo/tree/chore/tooling-ci-release-baseline) | 10/10 | Pins tooling, verifies sidecars, and constrains CI and release authority | [#60](https://github.com/SECHAK-AG/capptivo/pull/60) |
| [`chore/repository-eol-policy`](https://github.com/Neonsy/capptivo/tree/chore/repository-eol-policy) | 5/10 | Makes repository line endings deliberate across contributors | [#61](https://github.com/SECHAK-AG/capptivo/pull/61) |
| [`chore/dependency-advisories`](https://github.com/Neonsy/capptivo/tree/chore/dependency-advisories) | 8/10 | Removes known JavaScript dependency advisories | [#62](https://github.com/SECHAK-AG/capptivo/pull/62) |
| [`fix/export-file-authority`](https://github.com/Neonsy/capptivo/tree/fix/export-file-authority) | 10/10 | Keeps renderer input from selecting arbitrary export paths | [#63](https://github.com/SECHAK-AG/capptivo/pull/63) |
| [`fix/windows-display-affinity-contract`](https://github.com/Neonsy/capptivo/tree/fix/windows-display-affinity-contract) | 9/10 | Fails closed when recording controls cannot be excluded | [#65](https://github.com/SECHAK-AG/capptivo/pull/65) |
| [`fix/recorder-error-delivery`](https://github.com/Neonsy/capptivo/tree/fix/recorder-error-delivery) | 8/10 | Keeps fatal alerts visible and shows live nonfatal recorder notices | [#66](https://github.com/SECHAK-AG/capptivo/pull/66) |
| [`fix/structured-local-diagnostics`](https://github.com/Neonsy/capptivo/tree/fix/structured-local-diagnostics) | 8/10 | Stores bounded local failure codes without private event text | [#67](https://github.com/SECHAK-AG/capptivo/pull/67) |
| [`fix/encoder-frame-size-fallback`](https://github.com/Neonsy/capptivo/tree/fix/encoder-frame-size-fallback) | 9/10 | Falls back when a hardware encoder rejects a frame size | [#68](https://github.com/SECHAK-AG/capptivo/pull/68) |

## Bounded Windows changes

The lockfile moves the direct `windows-capture` resolution from 2.0.0 to 2.0.1 while retaining the existing manifest range and separate `scap` path
Upstream 2.0.1 drops a stale-size transition frame before invoking the application callback
That source-linked repair does not claim to reproduce or close issue #55

The WGC path matches only `DirectXError(FeatureLevelNotSatisfied)` after device creation
It explains the backend feature-level 11_0 requirement, default-adapter selection, and practical driver or hardware remedies
The 2.0.1 `UnexpectedNullResult` negative test prevents a broader message match
The README distinguishes the adapter condition from the Windows version floor

## Evidence and limits

The signed head `40a256b34b59a1668c42fd2d463adb56f6b4a50e` is pushed and read back from the fork
Its capture tree is unchanged from the earlier tested WGC head
The fresh component proof passed frozen offline installation, frontend tests, typecheck, and build
That component snapshot retained the inherited `src/annotation/engine.ts:948` lint finding
The full ten-contribution recomposition matches the prior native-validated tree byte for byte
The first native suite completed with an intermittent warmup-duration failure after 171 passing tests
Three cold-process runs on each of the final, interim, and older archives passed that test
An exact full-suite rerun passed 172 tests with no failures or ignored tests

- [x] Historical resolution selected 2.0.1 without unrelated targeted-update reselections
- [x] The typed negative test keeps `UnexpectedNullResult` outside the feature-level diagnostic
- [x] The unchanged capture tree retains its fresh component frontend proof
- [x] The full recomposition retains the exact GNU native-suite evidence
- [ ] Obtain hosted Windows compilation and selected-window capture evidence
- [ ] Prove runtime behavior on supported and unsupported device boundaries

The branch adds no WARP fallback, adapter selection, feature-level relaxation, or fork
The GNU evidence does not establish MSVC, desktop runtime, or physical capture behavior
