### PR TITLE
Fail closed when display-capture controls cannot be excluded

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ integration”, set Settings → Actions → General → Workflow permissions to
 Capptivo runs on:
 
 - **macOS** 13.0+
-- **Windows** 10 build 1903+ (May 2019 Update)
+- **Windows** 10 version 2004, build 19041 or later, required to keep Capptivo overlays out of recordings
 - **Linux** on modern distros with PipeWire 1.0+ (e.g. Ubuntu 24.04+) — X11 and Wayland
 
 Platform notes:

--- a/src-tauri/src/area_picker.rs
+++ b/src-tauri/src/area_picker.rs
@@ -6,14 +6,16 @@
 //! the same space scap/WGC use for source rects.
 
 use crate::error::{AppError, AppResult};
-use crate::recorder::types::{CaptureAreaSelection, CaptureCrop};
 #[cfg(target_os = "macos")]
 use crate::recorder::backend::picker_sources;
+use crate::recorder::types::{CaptureAreaSelection, CaptureCrop};
 #[cfg(target_os = "macos")]
 use core_graphics::display::CGDisplay;
-use tauri::{AppHandle, Emitter, Manager, PhysicalPosition, PhysicalSize, WebviewUrl, WebviewWindowBuilder};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::mpsc;
+use std::sync::{mpsc, Mutex};
+use tauri::{
+    AppHandle, Emitter, Manager, PhysicalPosition, PhysicalSize, WebviewUrl, WebviewWindowBuilder,
+};
 
 pub const AREA_PICKER_LABEL: &str = "area-picker";
 pub const AREA_FRAME_LABEL: &str = "area-frame";
@@ -24,6 +26,7 @@ const FRAME_OUTSET: f64 = 3.0;
 /// Bumped on every show/hide so a deferred Windows create can’t resurrect a
 /// guide the user already dismissed (or a newer show replaced).
 static FRAME_EPOCH: AtomicU64 = AtomicU64::new(0);
+static FRAME_OPERATION: Mutex<()> = Mutex::new(());
 
 struct VirtualDesktop {
     x: f64,
@@ -119,22 +122,18 @@ fn open_area_picker_window(app: &AppHandle) -> AppResult<()> {
     }
 
     let win = crate::webview_gpu::apply_gpu_args(
-        WebviewWindowBuilder::new(
-            app,
-            AREA_PICKER_LABEL,
-            WebviewUrl::App("area.html".into()),
-        )
-        .title("Select area")
-        .inner_size(vd.width, vd.height)
-        .position(vd.x, vd.y)
-        .resizable(false)
-        .decorations(false)
-        .transparent(true)
-        .shadow(false)
-        .always_on_top(true)
-        .accept_first_mouse(true)
-        .skip_taskbar(true)
-        .visible(true),
+        WebviewWindowBuilder::new(app, AREA_PICKER_LABEL, WebviewUrl::App("area.html".into()))
+            .title("Select area")
+            .inner_size(vd.width, vd.height)
+            .position(vd.x, vd.y)
+            .resizable(false)
+            .decorations(false)
+            .transparent(true)
+            .shadow(false)
+            .always_on_top(true)
+            .accept_first_mouse(true)
+            .skip_taskbar(true)
+            .visible(true),
     )
     .build()
     .map_err(|e| AppError::Other(format!("failed to open area picker: {e}")))?;
@@ -145,16 +144,17 @@ fn open_area_picker_window(app: &AppHandle) -> AppResult<()> {
     Ok(())
 }
 
-fn apply_picker_geometry(
-    win: &tauri::WebviewWindow,
-    vd: &VirtualDesktop,
-) -> AppResult<()> {
+fn apply_picker_geometry(win: &tauri::WebviewWindow, vd: &VirtualDesktop) -> AppResult<()> {
     let scale = win
         .scale_factor()
         .map_err(|e| AppError::Other(format!("scale factor: {e}")))?;
 
-    let _ = win.set_size(tauri::Size::Logical(tauri::LogicalSize::new(vd.width, vd.height)));
-    let _ = win.set_position(tauri::Position::Logical(tauri::LogicalPosition::new(vd.x, vd.y)));
+    let _ = win.set_size(tauri::Size::Logical(tauri::LogicalSize::new(
+        vd.width, vd.height,
+    )));
+    let _ = win.set_position(tauri::Position::Logical(tauri::LogicalPosition::new(
+        vd.x, vd.y,
+    )));
     let _ = win.set_position(tauri::Position::Physical(PhysicalPosition::new(
         (vd.x * scale) as i32,
         (vd.y * scale) as i32,
@@ -432,7 +432,16 @@ fn match_display_source(mx: f64, my: f64, mw: f64, mh: f64) -> AppResult<String>
     let mut best: Option<(u32, f64)> = None;
     for (id, _) in picker_sources::list_displays()? {
         let b = CGDisplay::new(id).bounds();
-        let overlap = rect_overlap(mx, my, mw, mh, b.origin.x, b.origin.y, b.size.width, b.size.height);
+        let overlap = rect_overlap(
+            mx,
+            my,
+            mw,
+            mh,
+            b.origin.x,
+            b.origin.y,
+            b.size.width,
+            b.size.height,
+        );
         if overlap > 0.0 {
             let prev = best.map(|(_, o)| o).unwrap_or(0.0);
             if overlap > prev {
@@ -466,12 +475,13 @@ fn rect_overlap(ax: f64, ay: f64, aw: f64, ah: f64, bx: f64, by: f64, bw: f64, b
 /// New WebView creation is deferred (`defer_on_ui`) — same Windows WebView2
 /// rule as camera/library/editor (blank HWND if built inside sync IPC).
 pub fn show_area_frame_guide(app: &AppHandle, selection: &CaptureAreaSelection) -> AppResult<()> {
+    // Claim the request before geometry lookup so a concurrent hide can cancel
+    // the whole operation, including work that has not reached the HWND yet.
     let epoch = FRAME_EPOCH.fetch_add(1, Ordering::AcqRel) + 1;
     let bounds = selection_frame_bounds(app, selection)?;
 
     if let Some(win) = app.get_webview_window(AREA_FRAME_LABEL) {
-        apply_frame_geometry(&win, &bounds)?;
-        return present_area_frame(app, &win, selection, &bounds);
+        return present_area_frame(app, &win, selection, &bounds, epoch);
     }
 
     let selection = selection.clone();
@@ -492,46 +502,39 @@ fn create_and_present_area_frame(
     selection: &CaptureAreaSelection,
     epoch: u64,
 ) -> AppResult<()> {
+    let _operation = FRAME_OPERATION.lock().unwrap_or_else(|e| e.into_inner());
     if FRAME_EPOCH.load(Ordering::Acquire) != epoch {
         return Ok(());
     }
     let bounds = selection_frame_bounds(app, selection)?;
     // Race: another deferred create may have won.
     if app.get_webview_window(AREA_FRAME_LABEL).is_none() {
-        let win = crate::webview_gpu::apply_gpu_args(
-            WebviewWindowBuilder::new(
-                app,
-                AREA_FRAME_LABEL,
-                WebviewUrl::App("frame.html".into()),
-            )
-            .title("Area guide")
-            .inner_size(bounds.width, bounds.height)
-            .position(bounds.x, bounds.y)
-            .resizable(false)
-            .decorations(false)
-            .transparent(true)
-            .shadow(false)
-            .always_on_top(true)
-            .skip_taskbar(true)
-            .focused(false)
-            .visible(false),
+        crate::webview_gpu::apply_gpu_args(
+            WebviewWindowBuilder::new(app, AREA_FRAME_LABEL, WebviewUrl::App("frame.html".into()))
+                .title("Area guide")
+                .inner_size(bounds.width, bounds.height)
+                .position(bounds.x, bounds.y)
+                .resizable(false)
+                .decorations(false)
+                .transparent(true)
+                .shadow(false)
+                .always_on_top(true)
+                .skip_taskbar(true)
+                .focused(false)
+                .visible(false),
         )
         .build()
         .map_err(|e| AppError::Other(format!("failed to open area frame: {e}")))?;
-        apply_frame_geometry(&win, &bounds)?;
-    } else if let Some(win) = app.get_webview_window(AREA_FRAME_LABEL) {
-        apply_frame_geometry(&win, &bounds)?;
     }
     if FRAME_EPOCH.load(Ordering::Acquire) != epoch {
-        // Don't bump epoch — a newer show/hide owns it. Just park if we raced
-        // a hide that ran before the HWND existed.
-        park_area_frame(app);
         return Ok(());
     }
     let Some(win) = app.get_webview_window(AREA_FRAME_LABEL) else {
-        return Err(AppError::Other("area frame window missing after open".into()));
+        return Err(AppError::Other(
+            "area frame window missing after open".into(),
+        ));
     };
-    present_area_frame(app, &win, selection, &bounds)
+    present_area_frame_locked(app, &win, selection, &bounds, epoch)
 }
 
 fn present_area_frame(
@@ -539,16 +542,39 @@ fn present_area_frame(
     win: &tauri::WebviewWindow,
     selection: &CaptureAreaSelection,
     bounds: &FrameBounds,
+    epoch: u64,
 ) -> AppResult<()> {
+    let _operation = FRAME_OPERATION.lock().unwrap_or_else(|e| e.into_inner());
+    present_area_frame_locked(app, win, selection, bounds, epoch)
+}
+
+fn present_area_frame_locked(
+    app: &AppHandle,
+    win: &tauri::WebviewWindow,
+    selection: &CaptureAreaSelection,
+    bounds: &FrameBounds,
+    epoch: u64,
+) -> AppResult<()> {
+    if FRAME_EPOCH.load(Ordering::Acquire) != epoch {
+        return Ok(());
+    }
+    apply_frame_geometry(win, bounds)?;
     // Must be click-through: an interactive always-on-top frame eats the desktop.
     win.set_ignore_cursor_events(true).map_err(|e| {
-        hide_area_frame_guide(app);
-        AppError::Other(format!(
-            "area guide could not enable click-through: {e}"
-        ))
+        FRAME_EPOCH.fetch_add(1, Ordering::AcqRel);
+        park_area_frame(app);
+        AppError::Other(format!("area guide could not enable click-through: {e}"))
     })?;
     let _ = win.set_always_on_top(true);
-    crate::windows::exclude_overlay_from_capture(win);
+    if FRAME_EPOCH.load(Ordering::Acquire) != epoch {
+        return Ok(());
+    }
+    crate::windows::show_capture_overlay(app, win).map_err(|e| {
+        let _ = win.hide();
+        AppError::Other(format!(
+            "area guide could not be shown with capture exclusion: {e}"
+        ))
+    })?;
     let scale = win.scale_factor().unwrap_or(1.0);
     tracing::info!(
         source_id = %selection.source_id,
@@ -563,7 +589,6 @@ fn present_area_frame(
         scale,
         "area frame guide shown"
     );
-    let _ = win.show();
     // Last word on focus must be the recorder bar, not the guide: `show()` above
     // activates the guide on every reuse (tao clears a window's don't-focus
     // marker after the first show), and the bar's Escape-to-cancel handler is a
@@ -574,6 +599,7 @@ fn present_area_frame(
 }
 
 pub fn hide_area_frame_guide(app: &AppHandle) {
+    let _operation = FRAME_OPERATION.lock().unwrap_or_else(|e| e.into_inner());
     FRAME_EPOCH.fetch_add(1, Ordering::AcqRel);
     park_area_frame(app);
 }
@@ -582,7 +608,9 @@ fn park_area_frame(app: &AppHandle) {
     if let Some(win) = app.get_webview_window(AREA_FRAME_LABEL) {
         let _ = win.hide();
         // Park off-screen so a transient show/reuse cannot flash the old crop.
-        let _ = win.set_position(tauri::Position::Physical(PhysicalPosition::new(-10_000, -10_000)));
+        let _ = win.set_position(tauri::Position::Physical(PhysicalPosition::new(
+            -10_000, -10_000,
+        )));
         let _ = win.set_size(tauri::Size::Physical(PhysicalSize::new(1, 1)));
     }
 }
@@ -602,10 +630,7 @@ fn apply_frame_geometry(win: &tauri::WebviewWindow, bounds: &FrameBounds) -> App
     Ok(())
 }
 
-fn selection_frame_bounds(
-    app: &AppHandle,
-    sel: &CaptureAreaSelection,
-) -> AppResult<FrameBounds> {
+fn selection_frame_bounds(app: &AppHandle, sel: &CaptureAreaSelection) -> AppResult<FrameBounds> {
     let (mx, my) = monitor_origin_for_source(app, &sel.source_id)?;
     let c = sel.crop;
     Ok(frame_guide_bounds(mx + c.x, my + c.y, c.width, c.height))
@@ -638,7 +663,9 @@ mod frame_guide_tests {
 #[cfg(target_os = "windows")]
 fn monitor_origin_for_source(_app: &AppHandle, source_id: &str) -> AppResult<(f64, f64)> {
     let Some(("display", id_str)) = source_id.split_once(':') else {
-        return Err(AppError::InvalidSource(format!("expected display id, got {source_id}")));
+        return Err(AppError::InvalidSource(format!(
+            "expected display id, got {source_id}"
+        )));
     };
     let display_id: isize = id_str
         .parse()
@@ -653,7 +680,9 @@ fn monitor_origin_for_source(_app: &AppHandle, source_id: &str) -> AppResult<(f6
 #[cfg(target_os = "macos")]
 fn monitor_origin_for_source(app: &AppHandle, source_id: &str) -> AppResult<(f64, f64)> {
     let Some(("display", id_str)) = source_id.split_once(':') else {
-        return Err(AppError::InvalidSource(format!("expected display id, got {source_id}")));
+        return Err(AppError::InvalidSource(format!(
+            "expected display id, got {source_id}"
+        )));
     };
     let display_id: u32 = id_str
         .parse()
@@ -671,7 +700,16 @@ fn monitor_origin_for_source(app: &AppHandle, source_id: &str) -> AppResult<(f64
         let my = m.position().y as f64 / scale;
         let mw = m.size().width as f64 / scale;
         let mh = m.size().height as f64 / scale;
-        let overlap = rect_overlap(mx, my, mw, mh, b.origin.x, b.origin.y, b.size.width, b.size.height);
+        let overlap = rect_overlap(
+            mx,
+            my,
+            mw,
+            mh,
+            b.origin.x,
+            b.origin.y,
+            b.size.width,
+            b.size.height,
+        );
         if overlap > 0.0 {
             let prev = best.map(|(_, _, o)| o).unwrap_or(0.0);
             if overlap > prev {

--- a/src-tauri/src/commands/recording.rs
+++ b/src-tauri/src/commands/recording.rs
@@ -95,15 +95,6 @@ pub fn recorder_state(state: State<AppState>) -> RecorderState {
     state.recorder.state()
 }
 
-/// `(async)` — the body creates the project directory, writes and fsyncs the
-/// recording stub, and brings the whole capture pipeline up (~330 ms; see the
-/// `starting` state in `src/windows/recorder/RecorderApp.tsx`). On the main
-/// thread that is a visible freeze of every window right as the countdown ends.
-///
-/// The post-start chrome calls are safe off-main: `set_capture_exclusion` is an
-/// empty no-op on macOS (`windows.rs`) and its Windows arm is already invoked
-/// off-main by [`stop_recording`], which is an `async fn`; the `emit_*` calls
-/// are Tauri events, which are thread-safe by construction.
 /// `(async)` — raises/unminimizes a window source during the countdown so the
 /// user sees what will be recorded before capture starts.
 #[tauri::command(async)]
@@ -119,12 +110,25 @@ pub fn prepare_window_capture(source_id: String) -> AppResult<()> {
     Ok(())
 }
 
+/// `(async)` — creates the project directory, writes and fsyncs the recording
+/// stub, and brings the capture pipeline up (~330 ms; see the `starting` state
+/// in `src/windows/recorder/RecorderApp.tsx`). On the main thread that would
+/// freeze every window as the countdown ends.
+///
+/// Display capture excludes Capptivo chrome before the backend can receive its
+/// first frame. Selected-window capture does not need display affinity because
+/// its WGC target is one HWND. The `emit_*` calls are thread-safe Tauri events.
 #[tauri::command(async)]
 pub fn start_recording(
     app: AppHandle,
     state: State<AppState>,
     config: RecorderConfig,
 ) -> AppResult<()> {
+    let _transition = state
+        .recording_transition
+        .try_lock()
+        .map_err(|_| AppError::Busy("starting or stopping".into()))?;
+
     if state.current_project.lock().is_some() {
         return Err(AppError::Busy("recording".into()));
     }
@@ -140,11 +144,22 @@ pub fn start_recording(
         config: config.clone(),
     });
 
+    let captures_display = config.source_id.starts_with("display:");
+    if captures_display {
+        if let Err(e) = windows::enable_capture_exclusion(&app) {
+            let _ = state.current_project.lock().take();
+            windows::clear_capture_exclusion(&app);
+            let _ = state.store.delete(&id);
+            return Err(AppError::Other(format!(
+                "could not exclude Capptivo controls from the recording: {e}"
+            )));
+        }
+    }
+
     // Native screen first; `start()` returns once capture is live — then start
     // the face-cam MediaRecorder.
     match state.recorder.start(&config, &dir) {
         Ok(()) => {
-            windows::set_capture_exclusion(&app, true);
             if app.get_webview_window(windows::CAMERA_LABEL).is_some() {
                 windows::emit_camera_capture_start(&app, &id);
             }
@@ -152,6 +167,9 @@ pub fn start_recording(
         }
         Err(e) => {
             let _ = state.current_project.lock().take();
+            if captures_display {
+                windows::clear_capture_exclusion(&app);
+            }
             let _ = state.store.delete(&id);
             Err(e)
         }
@@ -277,13 +295,16 @@ pub async fn finish_camera_file(state: State<'_, AppState>) -> AppResult<Option<
 /// while SCK is still live would paint the shell into the last frames.
 #[tauri::command]
 pub async fn stop_recording(app: AppHandle, state: State<'_, AppState>) -> AppResult<String> {
+    // A stop emitted by an early backend failure can arrive before startup has
+    // returned. Wait for that transition instead of dropping the only stop.
+    let transition = state.recording_transition.lock().await;
+
     // Read, do not take. `current_project` is the only thing preventing a second
     // `start_recording` (see the `Busy` guard), so it must stay in place until
     // the capture backend has actually stopped — clearing it up front is what
     // used to leave the app believing it was idle while the HUD was still up and
-    // capture exclusion still applied. Concurrent stops are still safe:
-    // `RecorderController::stop` claims its own `active` atomically, so the
-    // losing caller gets `NotRecording` from there.
+    // capture exclusion still applied. The transition mutex serializes
+    // concurrent stops before they read this session.
     //
     // The guard is dropped at the end of this statement — it must not be held
     // across the `await` below.
@@ -311,10 +332,9 @@ pub async fn stop_recording(app: AppHandle, state: State<'_, AppState>) -> AppRe
         Err(e) => (None, Some(e)),
     };
 
-    // `RecorderController::stop` has already joined the encode thread — holding
-    // the session open protects nothing. Retire it on every path so a failed
-    // stop never wedges `start_recording` or leaves overlays up.
-    let _ = state.current_project.lock().take();
+    // `RecorderController::stop` has already joined the encode thread. Keep the
+    // session published until its overlays are hidden so late overlay work is
+    // ordered before the final affinity reset below.
     let _ = state.camera_sink.lock().take();
     let config = current.config;
 
@@ -323,7 +343,15 @@ pub async fn stop_recording(app: AppHandle, state: State<'_, AppState>) -> AppRe
     let _ = windows::hide_annotation_overlay(app.clone());
     let _ = windows::dismiss_camera_preview(app.clone());
     crate::area_picker::hide_area_frame_guide(&app);
-    windows::set_capture_exclusion(&app, false);
+
+    // This lock is also used by late overlay shows. Reset affinity and retire
+    // the session as one operation so no overlay can restore affinity after it.
+    {
+        let mut current_project = state.current_project.lock();
+        windows::clear_capture_exclusion(&app);
+        let _ = current_project.take();
+    }
+    drop(transition);
 
     if let Some(e) = stop_err {
         tracing::error!(

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -11,6 +11,7 @@ use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::path::PathBuf;
 use std::sync::Arc;
+use tauri::async_runtime::Mutex as AsyncMutex;
 use tauri::{AppHandle, Emitter, Manager};
 
 pub struct AppState {
@@ -19,6 +20,8 @@ pub struct AppState {
     /// The recording currently being captured (set on start, cleared on stop).
     /// Holds the config so `stop_recording` can finalize the project manifest.
     pub current_project: Mutex<Option<CurrentProject>>,
+    /// Serializes start and stop. Stop holds it through overlay-affinity cleanup.
+    pub(crate) recording_transition: AsyncMutex<()>,
     /// Open export file sinks, keyed by handle id (see `commands::export`).
     pub exports: Mutex<HashMap<u64, ExportSink>>,
     /// Annex-B H.264 → ffmpeg MP4 sessions (see `commands::export` h264 stream).
@@ -78,6 +81,7 @@ impl AppState {
             recorder,
             store,
             current_project: Mutex::new(None),
+            recording_transition: AsyncMutex::new(()),
             exports: Mutex::new(HashMap::new()),
             h264_exports: Mutex::new(HashMap::new()),
             rawvideo_exports: Mutex::new(HashMap::new()),

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -454,7 +454,8 @@ fn set_follows_spaces(_win: &tauri::WebviewWindow, _follows: bool) {}
 /// Annotation is deliberately omitted — ink is meant to land in the recording.
 /// Area frame is chrome (crop guide), never content. Editor / library are never
 /// listed (title-based matching used to collide with the HUD's `"Capptivo"`
-/// title and black out fullscreen shells).
+/// title and black out fullscreen shells). Invisible exclusion requires Windows
+/// 10 version 2004, build 19041 or later.
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 const CAPTURE_EXCLUDED_LABELS: &[&str] = &[RECORDER_LABEL, CAMERA_LABEL, "area-frame"];
 
@@ -484,28 +485,51 @@ pub fn overlay_cgwindow_ids(app: &AppHandle) -> Vec<u32> {
 }
 
 #[cfg(target_os = "windows")]
-pub fn set_capture_exclusion(app: &AppHandle, excluded: bool) {
+pub fn enable_capture_exclusion(app: &AppHandle) -> tauri::Result<()> {
     use windows::Win32::UI::WindowsAndMessaging::{WDA_EXCLUDEFROMCAPTURE, WDA_NONE};
 
-    let affinity = if excluded {
-        WDA_EXCLUDEFROMCAPTURE
-    } else {
-        WDA_NONE
-    };
+    let mut excluded_windows = Vec::with_capacity(CAPTURE_EXCLUDED_LABELS.len());
     for label in CAPTURE_EXCLUDED_LABELS {
         let Some(win) = app.get_webview_window(label) else {
             continue;
         };
-        apply_display_affinity(&win, affinity, label);
+        if let Err(e) = apply_display_affinity(&win, WDA_EXCLUDEFROMCAPTURE, label) {
+            for (excluded_label, excluded_window) in excluded_windows {
+                if let Err(reset_error) =
+                    apply_display_affinity(&excluded_window, WDA_NONE, excluded_label)
+                {
+                    tracing::warn!(
+                        %reset_error,
+                        label = excluded_label,
+                        "failed to roll back capture exclusion"
+                    );
+                }
+            }
+            return Err(e);
+        }
+        excluded_windows.push((*label, win));
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+pub fn clear_capture_exclusion(app: &AppHandle) {
+    use windows::Win32::UI::WindowsAndMessaging::WDA_NONE;
+
+    for label in CAPTURE_EXCLUDED_LABELS {
+        let Some(win) = app.get_webview_window(label) else {
+            continue;
+        };
+        if let Err(e) = apply_display_affinity(&win, WDA_NONE, label) {
+            tracing::warn!(%e, label, "failed to clear capture exclusion");
+        }
     }
 }
 
-/// Mark one overlay HWND as capture-excluded. Used when chrome is shown after
-/// `set_capture_exclusion(true)` already ran (area frame after record start).
 #[cfg(target_os = "windows")]
-pub fn exclude_overlay_from_capture(win: &tauri::WebviewWindow) {
+fn exclude_overlay_from_capture(win: &tauri::WebviewWindow) -> tauri::Result<()> {
     use windows::Win32::UI::WindowsAndMessaging::WDA_EXCLUDEFROMCAPTURE;
-    apply_display_affinity(win, WDA_EXCLUDEFROMCAPTURE, "overlay");
+    apply_display_affinity(win, WDA_EXCLUDEFROMCAPTURE, win.label())
 }
 
 #[cfg(target_os = "windows")]
@@ -513,31 +537,77 @@ fn apply_display_affinity(
     win: &tauri::WebviewWindow,
     affinity: windows::Win32::UI::WindowsAndMessaging::WINDOW_DISPLAY_AFFINITY,
     label: &str,
-) {
+) -> tauri::Result<()> {
     use windows::Win32::Foundation::HWND;
     use windows::Win32::UI::WindowsAndMessaging::SetWindowDisplayAffinity;
 
-    let Ok(hwnd) = win.hwnd() else {
-        return;
-    };
+    let hwnd = win.hwnd().map_err(|e| {
+        tauri::Error::Anyhow(anyhow::anyhow!(
+            "failed to access the `{label}` window handle: {e}"
+        ))
+    })?;
     let hwnd = HWND(hwnd.0 as *mut std::ffi::c_void);
-    if let Err(e) = unsafe { SetWindowDisplayAffinity(hwnd, affinity) } {
-        tracing::warn!(%e, label, "failed to set capture exclusion");
-    }
+    unsafe { SetWindowDisplayAffinity(hwnd, affinity) }.map_err(|e| {
+        tauri::Error::Anyhow(anyhow::anyhow!(
+            "failed to set display affinity for `{label}`: {e}"
+        ))
+    })
 }
 
 #[cfg(not(target_os = "windows"))]
-pub fn set_capture_exclusion(_app: &AppHandle, _excluded: bool) {}
+pub fn enable_capture_exclusion(_app: &AppHandle) -> tauri::Result<()> {
+    Ok(())
+}
 
 #[cfg(not(target_os = "windows"))]
-pub fn exclude_overlay_from_capture(_win: &tauri::WebviewWindow) {}
+pub fn clear_capture_exclusion(_app: &AppHandle) {}
 
-/// Whether a recording is currently active (used to apply capture exclusion to
-/// overlay windows created mid-recording, e.g. the camera bubble).
-fn recording_active(app: &AppHandle) -> bool {
-    app.try_state::<crate::state::AppState>()
-        .map(|s| s.recorder.state().is_active())
-        .unwrap_or(false)
+/// Show recorder chrome only after its Windows capture exclusion is active.
+/// Holding `current_project` through both operations orders late windows before
+/// the final affinity reset in `stop_recording`.
+#[cfg(target_os = "windows")]
+pub(crate) fn show_capture_overlay(
+    app: &AppHandle,
+    win: &tauri::WebviewWindow,
+) -> tauri::Result<()> {
+    let Some(state) = app.try_state::<crate::state::AppState>() else {
+        return win.show();
+    };
+    let current_project = state.current_project.lock();
+    let captures_display = current_project
+        .as_ref()
+        .map(|project| project.config.source_id.starts_with("display:"))
+        .unwrap_or(false);
+    if !captures_display {
+        return win.show();
+    }
+
+    if let Err(e) = exclude_overlay_from_capture(win) {
+        let _ = win.hide();
+        return Err(e);
+    }
+    if let Err(e) = win.show() {
+        use windows::Win32::UI::WindowsAndMessaging::WDA_NONE;
+        if let Err(reset_error) = apply_display_affinity(win, WDA_NONE, win.label()) {
+            tracing::warn!(
+                %reset_error,
+                label = win.label(),
+                "failed to clear capture exclusion after show failed"
+            );
+        }
+        let _ = win.hide();
+        return Err(e);
+    }
+    drop(current_project);
+    Ok(())
+}
+
+#[cfg(not(target_os = "windows"))]
+pub(crate) fn show_capture_overlay(
+    _app: &AppHandle,
+    win: &tauri::WebviewWindow,
+) -> tauri::Result<()> {
+    win.show()
 }
 
 fn pin_to_all_spaces_if_shown(win: &tauri::WebviewWindow) {
@@ -1312,7 +1382,7 @@ pub fn show_recorder_popover(app: &AppHandle) -> tauri::Result<()> {
             }
         }
         set_follows_spaces(&win, true);
-        win.show()?;
+        show_capture_overlay(app, &win)?;
         win.set_focus()?;
         if geometry().layout.is_setup_bar() {
             ensure_setup_click_through(app.clone());
@@ -1368,7 +1438,7 @@ fn create_recorder_popover(app: &AppHandle) -> tauri::Result<()> {
     .build()?;
     apply_setup_overlay(app, &win)?;
     set_follows_spaces(&win, true);
-    win.show()?;
+    show_capture_overlay(app, &win)?;
     win.set_focus()?;
     ensure_setup_click_through(app.clone());
     let _ = app.emit("recorder://shown", ());
@@ -1409,7 +1479,7 @@ pub fn show_camera_preview(app: AppHandle, device_id: String) -> tauri::Result<(
         }
         let _ = win.set_content_protected(false);
         set_follows_spaces(&win, true);
-        win.show()?;
+        show_capture_overlay(&app, &win)?;
         return Ok(());
     }
 
@@ -1432,7 +1502,7 @@ fn create_camera_preview_window(app: &AppHandle, device_id: &str) -> tauri::Resu
         let _ = win.emit(CAMERA_DEVICE_EVENT, device_id);
         let _ = win.set_content_protected(false);
         set_follows_spaces(&win, true);
-        win.show()?;
+        show_capture_overlay(app, &win)?;
         return Ok(());
     }
 
@@ -1462,12 +1532,7 @@ fn create_camera_preview_window(app: &AppHandle, device_id: &str) -> tauri::Resu
     .build()?;
     let _ = win.set_content_protected(false);
     set_follows_spaces(&win, true);
-    win.show()?;
-    // Bubble opened mid-recording: apply the Windows capture opt-out now
-    // (recordings started later re-apply it to all overlay chrome).
-    if recording_active(app) {
-        set_capture_exclusion(app, true);
-    }
+    show_capture_overlay(app, &win)?;
     Ok(())
 }
 
@@ -1505,7 +1570,7 @@ pub fn set_camera_preview_visible(app: AppHandle, visible: bool) -> tauri::Resul
     if let Some(win) = app.get_webview_window(CAMERA_LABEL) {
         if visible {
             set_follows_spaces(&win, true);
-            win.show()?;
+            show_capture_overlay(&app, &win)?;
         } else {
             set_follows_spaces(&win, false);
             win.hide()?;

--- a/src/windows/recorder/store.ts
+++ b/src/windows/recorder/store.ts
@@ -761,9 +761,6 @@ export const useRecorderStore = create<RecorderStore>((set, get) => {
       prewarmInFlight = null;
       await commands.startRecording(config);
       set({ micSessionMuted: false });
-      if (captureMode === "area" && areaSelection) {
-        await commands.showAreaFrameGuide(areaSelection).catch(() => undefined);
-      }
     } catch (e) {
       reportError(describeError(e));
       // Warm mic was taken for the failed start — reopen if still selected.


### PR DESCRIPTION
# Fail closed when display-capture controls cannot be excluded

Windows display capture can include its controls when exclusion fails, as traced by a multi-pass human-in-the-loop review with agentic coding
Windows 10 version 2004, build 19041 is the approved floor for excluding recording controls before display capture starts

## Contribution map

| Branch | Score | Why it matters | Pull request |
| --- | --- | --- | --- |
| [`fix/windows-crlf-cursor-hotspot-check`](https://github.com/Neonsy/capptivo/tree/fix/windows-crlf-cursor-hotspot-check) | 6/10 | Makes the cursor inventory stable across Windows and Unix line endings | [#59](https://github.com/SECHAK-AG/capptivo/pull/59) |
| [`chore/tooling-ci-release-baseline`](https://github.com/Neonsy/capptivo/tree/chore/tooling-ci-release-baseline) | 10/10 | Pins tooling, verifies sidecars, and constrains CI and release authority | [#60](https://github.com/SECHAK-AG/capptivo/pull/60) |
| [`chore/repository-eol-policy`](https://github.com/Neonsy/capptivo/tree/chore/repository-eol-policy) | 5/10 | Makes repository line endings deliberate across contributors | [#61](https://github.com/SECHAK-AG/capptivo/pull/61) |
| [`chore/dependency-advisories`](https://github.com/Neonsy/capptivo/tree/chore/dependency-advisories) | 8/10 | Removes known JavaScript dependency advisories | [#62](https://github.com/SECHAK-AG/capptivo/pull/62) |
| [`fix/export-file-authority`](https://github.com/Neonsy/capptivo/tree/fix/export-file-authority) | 10/10 | Keeps renderer input from selecting arbitrary export paths | [#63](https://github.com/SECHAK-AG/capptivo/pull/63) |
| [`fix/windows-window-capture`](https://github.com/Neonsy/capptivo/tree/fix/windows-window-capture) | 7/10 | Updates selected-window capture and explains its narrow WGC device limit | [#64](https://github.com/SECHAK-AG/capptivo/pull/64) |
| [`fix/recorder-error-delivery`](https://github.com/Neonsy/capptivo/tree/fix/recorder-error-delivery) | 8/10 | Keeps fatal alerts visible and shows live nonfatal recorder notices | [#66](https://github.com/SECHAK-AG/capptivo/pull/66) |
| [`fix/structured-local-diagnostics`](https://github.com/Neonsy/capptivo/tree/fix/structured-local-diagnostics) | 8/10 | Stores bounded local failure codes without private event text | [#67](https://github.com/SECHAK-AG/capptivo/pull/67) |
| [`fix/encoder-frame-size-fallback`](https://github.com/Neonsy/capptivo/tree/fix/encoder-frame-size-fallback) | 9/10 | Falls back when a hardware encoder rejects a frame size | [#68](https://github.com/SECHAK-AG/capptivo/pull/68) |

## Capture starts from a protected UI state

Display and area capture require successful exclusion of recorder, camera, and area-guide windows already present
Late-created controls receive the same protection before they become visible
Selected-window capture remains outside this display-affinity preflight
Partial failure restores prior affinity, clears unfinished state, and returns an actionable startup error
The README explains the support floor and its security rationale

## Rebase status

The independent main rebuild is complete
The fresh archive snapshot passed frozen installation, typecheck, and build
The frontend test passed with task-local Corepack shims where nested pnpm needed the snapshot pin
Lint still reports the inherited `src/annotation/engine.ts:948` finding
Hosted Windows checks and native capture proof remain pending

- [x] Historical work traced the documented `WDA_EXCLUDEFROMCAPTURE` contract and reviewed start, stop, failure, late-window, and area-guide ordering
- [x] Rust targets compiled and linked in the historical record
- [x] The fresh archive snapshot passed `corepack pnpm install --frozen-lockfile`, test, typecheck, and build
- [ ] `pnpm lint` still reports the inherited `src/annotation/engine.ts:948` finding
- [ ] Run hosted Windows compilation from the standalone PR revision
- [ ] Record display and area captures on Windows 10 build 19041 and Windows 11 with controls visible to the presenter

Compilation can support call ordering but cannot prove protected controls are invisible rather than black in a recording
The GNU integration run is not independent branch proof or MSVC or desktop-runtime proof

