### PR TITLE
Deliver recorder errors without hiding fatal alerts

### DIFF
--- a/src-tauri/src/commands/recording.rs
+++ b/src-tauri/src/commands/recording.rs
@@ -310,6 +310,7 @@ pub async fn stop_recording(app: AppHandle, state: State<'_, AppState>) -> AppRe
         Ok(Err(e)) => (None, Some(e)),
         Err(e) => (None, Some(e)),
     };
+    let window_action = recorder_stop_window_action(&state.recorder.state());
 
     // `RecorderController::stop` has already joined the encode thread — holding
     // the session open protects nothing. Retire it on every path so a failed
@@ -318,8 +319,24 @@ pub async fn stop_recording(app: AppHandle, state: State<'_, AppState>) -> AppRe
     let _ = state.camera_sink.lock().take();
     let config = current.config;
 
-    let _ = windows::restore_recorder_setup_layout(&app);
-    let _ = windows::hide_recorder(app.clone());
+    match window_action {
+        RecorderStopWindowAction::Hide => {
+            let _ = windows::restore_recorder_setup_layout(&app);
+            let _ = windows::hide_recorder(app.clone());
+        }
+        // Fatal errors are delivered to the recorder webview. Put that window in
+        // its full-work-area alert layout before the command returns instead of
+        // hiding the only renderer that can display the error
+        RecorderStopWindowAction::RevealAlert => {
+            // A tray click or hotkey can hide the HUD while recording. Reveal
+            // first: show_recorder_popover resets an inactive hidden window to
+            // setup, so the alert layout must follow it
+            let _ = windows::show_recorder_popover(&app);
+            let _ = windows::set_recorder_layout(app.clone(), "alert".into());
+            crate::recorder::cool_microphone();
+            let _ = app.emit("recorder://dismissed", ());
+        }
+    }
     let _ = windows::hide_annotation_overlay(app.clone());
     let _ = windows::dismiss_camera_preview(app.clone());
     crate::area_picker::hide_area_frame_guide(&app);
@@ -447,9 +464,50 @@ fn take_is_usable(frames_encoded: u64, screen_bytes: Option<u64>) -> bool {
     frames_encoded > 0 && screen_bytes.is_some_and(|b| b >= MIN_SCREEN_BYTES)
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RecorderStopWindowAction {
+    Hide,
+    RevealAlert,
+}
+
+/// The recorder owns fatal delivery, so it must stay visible until the UI handles it
+fn recorder_stop_window_action(state: &RecorderState) -> RecorderStopWindowAction {
+    if matches!(state, RecorderState::Error { fatal: true, .. }) {
+        RecorderStopWindowAction::RevealAlert
+    } else {
+        RecorderStopWindowAction::Hide
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::take_is_usable;
+    use super::{recorder_stop_window_action, take_is_usable, RecorderStopWindowAction};
+    use crate::recorder::types::RecorderState;
+
+    #[test]
+    fn fatal_stop_keeps_recorder_visible_for_its_alert() {
+        assert_eq!(
+            recorder_stop_window_action(&RecorderState::Error {
+                message: "encoder failed".into(),
+                fatal: true,
+            }),
+            RecorderStopWindowAction::RevealAlert
+        );
+        assert_eq!(
+            recorder_stop_window_action(&RecorderState::Error {
+                message: "notice".into(),
+                fatal: false,
+            }),
+            RecorderStopWindowAction::Hide
+        );
+        // A second stop races the first after it changed this state to
+        // `Finalizing`; that losing `NotRecording` path must retain the normal
+        // hide behavior rather than presenting a fatal alert
+        assert_eq!(
+            recorder_stop_window_action(&RecorderState::Finalizing),
+            RecorderStopWindowAction::Hide
+        );
+    }
 
     #[test]
     fn take_is_usable_rejects_zero_frames() {

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -109,6 +109,8 @@ const LAYOUT_ALERT_H: f64 = 120.0;
 const LAYOUT_HUD: (f64, f64) = (448.0, 56.0);
 /// Collapsed HUD chip (grip + REC + timer + expand).
 const LAYOUT_HUD_MINI: (f64, f64) = (196.0, 48.0);
+/// Live HUD with a temporary non-fatal recording notice
+const LAYOUT_HUD_NOTICE: (f64, f64) = (448.0, 128.0);
 /// Countdown badge (centered on the primary display).
 /// Must stay square — a wide leftover setup width makes the digit look
 /// top/bottom-cramped with huge side gaps.
@@ -123,6 +125,7 @@ enum RecorderLayout {
     Alert,
     Hud,
     HudMini,
+    HudNotice,
     Countdown,
 }
 
@@ -132,6 +135,7 @@ impl RecorderLayout {
             "alert" => Self::Alert,
             "hud" => Self::Hud,
             "hud-mini" => Self::HudMini,
+            "hud-notice" => Self::HudNotice,
             "countdown" => Self::Countdown,
             _ => Self::Setup,
         }
@@ -143,6 +147,7 @@ impl RecorderLayout {
             Self::Alert => LAYOUT_ALERT_H,
             Self::Hud => LAYOUT_HUD.1,
             Self::HudMini => LAYOUT_HUD_MINI.1,
+            Self::HudNotice => LAYOUT_HUD_NOTICE.1,
             Self::Countdown => LAYOUT_COUNTDOWN.1,
         }
     }
@@ -156,6 +161,7 @@ impl RecorderLayout {
             Self::Alert => (LAYOUT_SETUP_W_FALLBACK, LAYOUT_ALERT_H),
             Self::Hud => LAYOUT_HUD,
             Self::HudMini => LAYOUT_HUD_MINI,
+            Self::HudNotice => LAYOUT_HUD_NOTICE,
             Self::Countdown => LAYOUT_COUNTDOWN,
         };
         tauri::LogicalSize::new(w, h)
@@ -923,7 +929,7 @@ pub fn restore_recorder_setup_layout(app: &AppHandle) -> tauri::Result<()> {
     Ok(())
 }
 
-/// Resize the recorder window: `setup` | `alert` | `hud` | `hud-mini` |
+/// Resize the recorder window: `setup` | `alert` | `hud` | `hud-mini` | `hud-notice` |
 /// `countdown`. Setup/alert cover the monitor work area so the pill can
 /// CSS-drag and popovers can flip inside the window — never a per-drag resize.
 #[tauri::command]
@@ -2127,6 +2133,21 @@ pub fn close_editor_if_open(app: &AppHandle, project_id: &str) {
     let label = format!("{EDITOR_LABEL_PREFIX}{project_id}");
     if let Some(win) = app.get_webview_window(&label) {
         let _ = win.close();
+    }
+}
+
+#[cfg(test)]
+mod recorder_layout_tests {
+    use super::{RecorderLayout, LAYOUT_HUD_NOTICE};
+
+    #[test]
+    fn hud_notice_is_a_compact_docked_layout() {
+        let layout = RecorderLayout::parse("hud-notice");
+        let size = layout.size();
+        assert!(layout == RecorderLayout::HudNotice);
+        assert_eq!(size.width, LAYOUT_HUD_NOTICE.0);
+        assert_eq!(size.height, LAYOUT_HUD_NOTICE.1);
+        assert!(!layout.is_setup_bar());
     }
 }
 

--- a/src/ipc/bindings.ts
+++ b/src/ipc/bindings.ts
@@ -74,7 +74,7 @@ export const commands = {
   hideRecorder: () => invoke<void>("hide_recorder"),
   /** Resize recorder window to hug chrome. Popovers use `setRecorderMenu`. */
   setRecorderLayout: (
-    layout: "setup" | "alert" | "hud" | "hud-mini" | "countdown",
+    layout: "setup" | "alert" | "hud" | "hud-mini" | "hud-notice" | "countdown",
   ) => invoke<void>("set_recorder_layout", { layout }),
   /** Hug the setup pill — pass measured content width (logical px). */
   setRecorderBarWidth: (width: number) =>

--- a/src/windows/recorder/RecorderApp.tsx
+++ b/src/windows/recorder/RecorderApp.tsx
@@ -30,6 +30,7 @@ import { useRecorderStore } from "./store";
 import { Countdown } from "./Countdown";
 import { useBarDrag } from "./menuSurface";
 import { barTransform, type BarOffset } from "./barOffset";
+import { recorderHudLayout, recorderLiveNotice } from "./recorderErrorPresentation";
 import { RecorderToolbar } from "./RecorderToolbar";
 
 /** Keep in sync with `duration-300` on `BarPane`. */
@@ -103,6 +104,7 @@ export function RecorderApp() {
   // What the window shows. `starting` covers the pipeline bring-up window so the
   // HUD is on screen the instant the countdown ends.
   const showHud = live || starting;
+  const inactiveError = showHud ? null : lastError;
 
   // Esc dismisses the crop guide and leaves area mode (require re-pick).
   useEffect(() => {
@@ -160,11 +162,11 @@ export function RecorderApp() {
     setMountSetup(true);
     setHudOn(false);
     setHudEnter(false);
-    if (lastError) void commands.setRecorderLayout("alert");
+    if (inactiveError) void commands.setRecorderLayout("alert");
     else void commands.setRecorderLayout("setup");
     const id = window.setTimeout(() => setMountHud(false), BAR_CROSSFADE_MS);
     return () => window.clearTimeout(id);
-  }, [showHud, counting, lastError, resetBarOffset]);
+  }, [showHud, counting, inactiveError, resetBarOffset]);
 
   useEffect(() => {
     const inkLive = status === "recording" || status === "paused";
@@ -337,11 +339,14 @@ function BarPane({
 function RecordingHud({ starting }: { starting: boolean }) {
   const { t } = useI18n();
   const status = useRecorderStore((s) => s.state.status);
+  const live =
+    status === "recording" || status === "paused" || status === "finalizing";
   const elapsed = useRecorderStore((s) => s.elapsed);
   const micEnabled = useRecorderStore((s) => s.micEnabled);
   const micDeviceId = useRecorderStore((s) => s.micDeviceId);
   const micSessionMuted = useRecorderStore((s) => s.micSessionMuted);
   const annotationVisible = useRecorderStore((s) => s.annotationVisible);
+  const lastError = useRecorderStore((s) => s.lastError);
   const setAnnotationVisible = useRecorderStore((s) => s.setAnnotationVisible);
   const toggleMicMute = useRecorderStore((s) => s.toggleMicMute);
   const stop = useRecorderStore((s) => s.stopRecording);
@@ -361,20 +366,78 @@ function RecordingHud({ starting }: { starting: boolean }) {
     : micSessionMuted
       ? t("recorder.hud.mic.unmute")
       : t("recorder.hud.mic.mute");
+  const notice = recorderLiveNotice(lastError);
+  const hudLayout = recorderHudLayout(notice, collapsed, live);
 
   useEffect(() => {
-    void commands.setRecorderLayout(collapsed ? "hud-mini" : "hud");
-  }, [collapsed]);
+    if (!hudLayout) return;
+    void commands.setRecorderLayout(hudLayout);
+  }, [hudLayout]);
 
   if (collapsed) {
     return (
-      <div className="inline-flex h-10 w-fit items-center gap-0.5 rounded-2xl border border-border bg-card p-1">
+      <div
+        className={cn(
+          "inline-flex flex-col items-center gap-1",
+          notice ? "w-[448px]" : "w-fit",
+        )}
+      >
+        {notice ? <RecorderLiveNotice message={notice.message} /> : null}
+        <div className="inline-flex h-10 w-fit items-center gap-0.5 rounded-2xl border border-border bg-card p-1">
+          <div
+            className="flex h-8 cursor-grab items-center gap-1.5 rounded-xl pl-1 pr-2.5 active:cursor-grabbing"
+            title={t("recorder.drag")}
+            onPointerDown={startHudWindowDrag}
+          >
+            <span className="flex w-6 shrink-0 items-center justify-center text-muted-foreground">
+              <GripVertical className="pointer-events-none size-4" />
+            </span>
+            <span
+              className={cn(
+                "size-2 shrink-0 rounded-full",
+                paused ? "bg-muted-foreground" : "animate-pulse bg-primary",
+              )}
+            />
+            <span
+              className={cn(
+                "text-[11px] font-semibold tracking-wider",
+                paused ? "text-muted-foreground" : "text-primary",
+              )}
+            >
+              {paused ? t("recorder.hud.paused") : "REC"}
+            </span>
+            <span className="min-w-11 text-sm font-semibold tabular-nums text-foreground">
+              {formatElapsed(elapsed)}
+            </span>
+          </div>
+          <HudIconBtn
+            className="size-8"
+            title={t("recorder.hud.expand")}
+            aria-label={t("recorder.hud.expand")}
+            onClick={() => setCollapsed(false)}
+          >
+            <Maximize2 className="size-3.5" />
+          </HudIconBtn>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        "inline-flex max-w-full flex-col items-center gap-1",
+        notice ? "w-[448px]" : "w-fit",
+      )}
+    >
+      {notice ? <RecorderLiveNotice message={notice.message} /> : null}
+      <div className="inline-flex h-12 w-fit max-w-full items-center gap-0.5 rounded-2xl border border-border bg-card p-1.5">
         <div
-          className="flex h-8 cursor-grab items-center gap-1.5 rounded-xl pl-1 pr-2.5 active:cursor-grabbing"
+          className="flex h-9 cursor-grab items-center gap-1.5 rounded-xl pl-0.5 pr-2 active:cursor-grabbing"
           title={t("recorder.drag")}
           onPointerDown={startHudWindowDrag}
         >
-          <span className="flex w-6 shrink-0 items-center justify-center text-muted-foreground">
+          <span className="flex w-7 shrink-0 items-center justify-center text-muted-foreground">
             <GripVertical className="pointer-events-none size-4" />
           </span>
           <span
@@ -389,144 +452,117 @@ function RecordingHud({ starting }: { starting: boolean }) {
               paused ? "text-muted-foreground" : "text-primary",
             )}
           >
-            {paused ? t("recorder.hud.paused") : "REC"}
+            {finalizing
+              ? t("recorder.hud.finalizing")
+              : paused
+                ? t("recorder.hud.paused")
+                : "REC"}
           </span>
           <span className="min-w-11 text-sm font-semibold tabular-nums text-foreground">
             {formatElapsed(elapsed)}
           </span>
         </div>
-        <HudIconBtn
-          className="size-8"
-          title={t("recorder.hud.expand")}
-          aria-label={t("recorder.hud.expand")}
-          onClick={() => setCollapsed(false)}
-        >
-          <Maximize2 className="size-3.5" />
-        </HudIconBtn>
-      </div>
-    );
-  }
 
-  return (
-    <div className="inline-flex h-12 w-fit max-w-full items-center gap-0.5 rounded-2xl border border-border bg-card p-1.5">
-      <div
-        className="flex h-9 cursor-grab items-center gap-1.5 rounded-xl pl-0.5 pr-2 active:cursor-grabbing"
-        title={t("recorder.drag")}
-        onPointerDown={startHudWindowDrag}
-      >
-        <span className="flex w-7 shrink-0 items-center justify-center text-muted-foreground">
-          <GripVertical className="pointer-events-none size-4" />
-        </span>
-        <span
-          className={cn(
-            "size-2 shrink-0 rounded-full",
-            paused ? "bg-muted-foreground" : "animate-pulse bg-primary",
-          )}
-        />
-        <span
-          className={cn(
-            "text-[11px] font-semibold tracking-wider",
-            paused ? "text-muted-foreground" : "text-primary",
-          )}
-        >
-          {finalizing
-            ? t("recorder.hud.finalizing")
-            : paused
-              ? t("recorder.hud.paused")
-              : "REC"}
-        </span>
-        <span className="min-w-11 text-sm font-semibold tabular-nums text-foreground">
-          {formatElapsed(elapsed)}
-        </span>
-      </div>
+        <div className="mx-0.5 h-5 w-px shrink-0 bg-border" />
 
-      <div className="mx-0.5 h-5 w-px shrink-0 bg-border" />
+        {micArmed ? (
+          <HudIconBtn
+            disabled={busy}
+            title={micLabel}
+            aria-label={micLabel}
+            aria-pressed={micSessionMuted}
+            onClick={() => toggleMicMute()}
+            className={micSessionMuted ? "text-muted-foreground" : undefined}
+          >
+            {micSessionMuted ? (
+              <MicOff className="size-4" />
+            ) : (
+              <Mic className="size-4" />
+            )}
+          </HudIconBtn>
+        ) : (
+          <HudIconBtn
+            disabled
+            title={micLabel}
+            aria-label={micLabel}
+            className="text-muted-foreground/50"
+          >
+            <MicOff className="size-4" />
+          </HudIconBtn>
+        )}
 
-      {micArmed ? (
         <HudIconBtn
           disabled={busy}
-          title={micLabel}
-          aria-label={micLabel}
-          aria-pressed={micSessionMuted}
-          onClick={() => toggleMicMute()}
-          className={micSessionMuted ? "text-muted-foreground" : undefined}
+          title={paused ? t("recorder.hud.resume") : t("recorder.hud.pause")}
+          aria-label={paused ? t("recorder.hud.resume") : t("recorder.hud.pause")}
+          onClick={() => void togglePause()}
+          className={paused ? "text-primary" : undefined}
         >
-          {micSessionMuted ? (
-            <MicOff className="size-4" />
+          {paused ? (
+            <Play className="size-4 fill-current" />
           ) : (
-            <Mic className="size-4" />
+            <Pause className="size-4" />
           )}
         </HudIconBtn>
-      ) : (
+
         <HudIconBtn
-          disabled
-          title={micLabel}
-          aria-label={micLabel}
-          className="text-muted-foreground/50"
+          disabled={busy}
+          title={t("recorder.hud.stop")}
+          aria-label={t("recorder.hud.stop")}
+          onClick={() => void stop()}
+          className="text-primary hover:bg-primary/15 hover:text-primary"
         >
-          <MicOff className="size-4" />
+          <Square className="size-3.5 fill-current" />
         </HudIconBtn>
-      )}
 
-      <HudIconBtn
-        disabled={busy}
-        title={paused ? t("recorder.hud.resume") : t("recorder.hud.pause")}
-        aria-label={paused ? t("recorder.hud.resume") : t("recorder.hud.pause")}
-        onClick={() => void togglePause()}
-        className={paused ? "text-primary" : undefined}
-      >
-        {paused ? (
-          <Play className="size-4 fill-current" />
-        ) : (
-          <Pause className="size-4" />
-        )}
-      </HudIconBtn>
+        <HudIconBtn
+          disabled={busy}
+          title={annotateLabel}
+          aria-label={annotateLabel}
+          aria-pressed={annotationVisible}
+          onClick={() => setAnnotationVisible(!annotationVisible)}
+          className={
+            annotationVisible
+              ? "bg-primary/15 text-primary hover:bg-primary/20"
+              : undefined
+          }
+        >
+          <Pencil className="size-4" />
+        </HudIconBtn>
 
-      <HudIconBtn
-        disabled={busy}
-        title={t("recorder.hud.stop")}
-        aria-label={t("recorder.hud.stop")}
-        onClick={() => void stop()}
-        className="text-primary hover:bg-primary/15 hover:text-primary"
-      >
-        <Square className="size-3.5 fill-current" />
-      </HudIconBtn>
+        <div className="mx-0.5 h-5 w-px shrink-0 bg-border" />
 
-      <HudIconBtn
-        disabled={busy}
-        title={annotateLabel}
-        aria-label={annotateLabel}
-        aria-pressed={annotationVisible}
-        onClick={() => setAnnotationVisible(!annotationVisible)}
-        className={
-          annotationVisible
-            ? "bg-primary/15 text-primary hover:bg-primary/20"
-            : undefined
-        }
-      >
-        <Pencil className="size-4" />
-      </HudIconBtn>
+        <HudIconBtn
+          disabled={busy}
+          title={t("recorder.hud.collapse")}
+          aria-label={t("recorder.hud.collapse")}
+          onClick={() => setCollapsed(true)}
+        >
+          <Minus className="size-4" />
+        </HudIconBtn>
 
-      <div className="mx-0.5 h-5 w-px shrink-0 bg-border" />
-
-      <HudIconBtn
-        disabled={busy}
-        title={t("recorder.hud.collapse")}
-        aria-label={t("recorder.hud.collapse")}
-        onClick={() => setCollapsed(true)}
-      >
-        <Minus className="size-4" />
-      </HudIconBtn>
-
-      <HudIconBtn
-        disabled={busy}
-        title={t("recorder.hud.hide")}
-        aria-label={t("recorder.hud.hide")}
-        onClick={() => void commands.hideRecorder()}
-      >
-        <X className="size-4" />
-      </HudIconBtn>
+        <HudIconBtn
+          disabled={busy}
+          title={t("recorder.hud.hide")}
+          aria-label={t("recorder.hud.hide")}
+          onClick={() => void commands.hideRecorder()}
+        >
+          <X className="size-4" />
+        </HudIconBtn>
+      </div>
     </div>
+  );
+}
+
+function RecorderLiveNotice({ message }: { message: string }) {
+  return (
+    <p
+      role="status"
+      tabIndex={0}
+      className="min-w-0 w-full max-h-[74px] overflow-y-auto break-words rounded-xl border border-amber-500/40 bg-amber-500/10 px-2 py-1 text-[11px] font-medium leading-4 text-amber-700 dark:text-amber-400"
+    >
+      {message}
+    </p>
   );
 }
 

--- a/src/windows/recorder/RecorderErrorToast.tsx
+++ b/src/windows/recorder/RecorderErrorToast.tsx
@@ -8,8 +8,7 @@ import { X } from "lucide-react";
 import { useI18n } from "@/lib/settings";
 import { cn } from "@/lib/utils";
 import { useRecorderStore } from "./store";
-
-const DISMISS_MS = 6000;
+import { recorderErrorDismissDelay } from "./recorderErrorPresentation";
 /** Sit above the dock + recorder bar (bar ~56px + margin). */
 const TOAST_BOTTOM_PX = 88;
 
@@ -32,15 +31,20 @@ export function RecorderBarAnchor({ children }: { children: ReactNode }) {
 export function RecorderErrorToast({ className }: { className?: string }) {
   const { t } = useI18n();
   const error = useRecorderStore((s) => s.lastError);
+  const status = useRecorderStore((s) => s.state.status);
   const clear = () => useRecorderStore.setState({ lastError: null });
+  const live =
+    status === "recording" || status === "paused" || status === "finalizing";
 
   useEffect(() => {
-    if (!error?.trim()) return;
-    const id = window.setTimeout(clear, DISMISS_MS);
+    if (!error?.message.trim()) return;
+    const delay = recorderErrorDismissDelay(error);
+    if (delay === null) return;
+    const id = window.setTimeout(clear, delay);
     return () => window.clearTimeout(id);
   }, [error]);
 
-  if (!error?.trim()) return null;
+  if (!error?.message.trim() || (live && !error.fatal)) return null;
 
   return (
     <div
@@ -51,7 +55,7 @@ export function RecorderErrorToast({ className }: { className?: string }) {
         className,
       )}
     >
-      <p className="min-w-0 flex-1 break-words">{error}</p>
+      <p className="min-w-0 flex-1 break-words">{error.message}</p>
       <button
         type="button"
         aria-label={t("recorder.error.dismiss")}

--- a/src/windows/recorder/recorderErrorPresentation.selfcheck.ts
+++ b/src/windows/recorder/recorderErrorPresentation.selfcheck.ts
@@ -1,0 +1,92 @@
+import {
+  NON_FATAL_ERROR_DISMISS_MS,
+  nextRecorderError,
+  recorderErrorAfterLiveEnd,
+  recorderErrorDismissDelay,
+  recorderHudLayout,
+  recorderLiveNotice,
+} from "./recorderErrorPresentation.ts";
+
+function assertEqual<T>(actual: T, expected: T, message: string) {
+  if (actual !== expected) throw new Error(message);
+}
+
+assertEqual(
+  recorderErrorDismissDelay({ message: "encoder failed", fatal: true }),
+  null,
+  "fatal recorder errors must remain until dismissal",
+);
+assertEqual(
+  recorderErrorDismissDelay({ message: "recording scaled", fatal: false }),
+  NON_FATAL_ERROR_DISMISS_MS,
+  "non-fatal recorder notices retain the existing timeout",
+);
+
+const fatal = { message: "encoder failed", fatal: true };
+const earlierNotice = { message: "capture resized", fatal: false };
+const laterNotice = { message: "recording scaled", fatal: false };
+const laterFatal = { message: "disk unavailable", fatal: true };
+const blankNotice = { message: "  ", fatal: false };
+
+assertEqual(
+  nextRecorderError(earlierNotice, laterNotice),
+  laterNotice,
+  "the latest non-fatal notice must replace the prior non-fatal notice",
+);
+assertEqual(
+  nextRecorderError(fatal, laterNotice),
+  fatal,
+  "a delayed non-fatal notice must not replace a fatal alert",
+);
+assertEqual(
+  nextRecorderError(fatal, laterFatal),
+  laterFatal,
+  "the latest fatal error must replace the prior fatal error",
+);
+assertEqual(
+  recorderErrorAfterLiveEnd(earlierNotice),
+  null,
+  "a non-fatal notice must end with the take",
+);
+assertEqual(
+  recorderErrorAfterLiveEnd(fatal),
+  fatal,
+  "a fatal error must survive the end of the take",
+);
+assertEqual(
+  recorderHudLayout(earlierNotice, false, true),
+  "hud-notice",
+  "an expanded live HUD must reserve room for a non-fatal notice",
+);
+assertEqual(
+  recorderHudLayout(earlierNotice, true, true),
+  "hud-notice",
+  "a collapsed live HUD must expand for a non-fatal notice",
+);
+assertEqual(
+  recorderHudLayout(null, true, true),
+  "hud-mini",
+  "a collapsed HUD without a notice must remain compact",
+);
+assertEqual(
+  recorderHudLayout(fatal, false, true),
+  "hud",
+  "a fatal error must not select the temporary notice layout",
+);
+assertEqual(
+  recorderHudLayout(fatal, false, false),
+  null,
+  "an outgoing HUD must not replace the selected idle error layout",
+);
+assertEqual(
+  recorderLiveNotice(blankNotice),
+  null,
+  "a blank non-fatal notice must not reserve a live HUD layout",
+);
+assertEqual(
+  recorderHudLayout(recorderLiveNotice(blankNotice), false, true),
+  "hud",
+  "a blank non-fatal notice must leave the normal HUD frame in place",
+);
+
+console.log("recorderErrorPresentation.selfcheck: ok");

--- a/src/windows/recorder/recorderErrorPresentation.ts
+++ b/src/windows/recorder/recorderErrorPresentation.ts
@@ -1,0 +1,44 @@
+export interface RecorderErrorNotice {
+  message: string;
+  fatal: boolean;
+}
+
+export type RecorderHudLayout = "hud" | "hud-mini" | "hud-notice";
+
+export const NON_FATAL_ERROR_DISMISS_MS = 6000;
+
+export function nextRecorderError(
+  previous: RecorderErrorNotice | null,
+  next: RecorderErrorNotice,
+): RecorderErrorNotice {
+  return previous?.fatal && !next.fatal ? previous : next;
+}
+
+export function recorderErrorAfterLiveEnd(
+  error: RecorderErrorNotice | null,
+): RecorderErrorNotice | null {
+  return error?.fatal ? error : null;
+}
+
+export function recorderLiveNotice(
+  error: RecorderErrorNotice | null,
+): RecorderErrorNotice | null {
+  return error && !error.fatal && error.message.trim() ? error : null;
+}
+
+export function recorderHudLayout(
+  error: RecorderErrorNotice | null,
+  collapsed: boolean,
+  live: boolean,
+): RecorderHudLayout | null {
+  if (!live) return null;
+  if (error && !error.fatal) return "hud-notice";
+  return collapsed ? "hud-mini" : "hud";
+}
+
+/** Fatal recorder failures stay visible until the recorder owner dismisses them */
+export function recorderErrorDismissDelay(
+  error: RecorderErrorNotice,
+): number | null {
+  return error.fatal ? null : NON_FATAL_ERROR_DISMISS_MS;
+}

--- a/src/windows/recorder/store.ts
+++ b/src/windows/recorder/store.ts
@@ -23,6 +23,11 @@ import type {
 import { SCREEN_CAPTURE_FPS } from "./captureFps";
 import { probeCameraPermission } from "./cameraAccess";
 import { flushCameraCaptureWithTimeout } from "./flushCamera";
+import {
+  nextRecorderError,
+  recorderErrorAfterLiveEnd,
+  type RecorderErrorNotice,
+} from "./recorderErrorPresentation";
 import { logClientError, logClientInfo } from "@/lib/errorLogging";
 
 export type CaptureMode = CaptureSourceKind | "area" | "device";
@@ -43,7 +48,7 @@ interface RecorderStore {
   // --- projected from Rust ---
   state: RecorderState;
   elapsed: number;
-  lastError: string | null;
+  lastError: RecorderErrorNotice | null;
 
   // --- local UI ---
   permissions: PermissionStatus | null;
@@ -209,9 +214,19 @@ function resetAreaCapture(
   }
 }
 
+function isRecorderLive(state: RecorderState) {
+  return (
+    state.status === "recording" ||
+    state.status === "paused" ||
+    state.status === "finalizing"
+  );
+}
+
 export const useRecorderStore = create<RecorderStore>((set, get) => {
-  const reportError = (message: string) => {
-    set({ lastError: message });
+  const reportError = (message: string, fatal = false) => {
+    set((current) => ({
+      lastError: nextRecorderError(current.lastError, { message, fatal }),
+    }));
     logClientError("recorder", message);
   };
 
@@ -246,22 +261,23 @@ export const useRecorderStore = create<RecorderStore>((set, get) => {
       subscribed = true;
       await onStateChanged((state) => {
         set((prev) => {
-          const nextLive =
-            state.status === "recording" ||
-            state.status === "paused" ||
-            state.status === "finalizing";
-          const prevLive =
-            prev.state.status === "recording" ||
-            prev.state.status === "paused" ||
-            prev.state.status === "finalizing";
+          const nextLive = isRecorderLive(state);
+          const prevLive = isRecorderLive(prev.state);
           // New take — zero the HUD; `Elapsed` only ticks while the encode loop runs.
           const elapsed = nextLive && !prevLive ? 0 : prev.elapsed;
-          return { state, elapsed };
+          return {
+            state,
+            elapsed,
+            lastError:
+              prevLive && !nextLive
+                ? recorderErrorAfterLiveEnd(prev.lastError)
+                : prev.lastError,
+          };
         });
       });
       await onElapsed((seconds) => set({ elapsed: seconds }));
       await onError((message, fatal) => {
-        reportError(message);
+        reportError(message, fatal);
         if (!fatal) return;
         const { state } = get();
         if (state.status !== "recording" && state.status !== "paused") return;
@@ -506,7 +522,7 @@ export const useRecorderStore = create<RecorderStore>((set, get) => {
       }
     }
     try {
-      set({ lastError: null });
+      if (!get().lastError?.fatal) set({ lastError: null });
       const selection = await commands.pickCaptureArea();
       set({
         captureMode: "area",
@@ -799,7 +815,10 @@ export const useRecorderStore = create<RecorderStore>((set, get) => {
       void commands.hideCameraPreview().catch(() => undefined);
       set({ annotationVisible: false, micSessionMuted: false });
     } catch (e) {
-      reportError(describeError(e));
+      // Fatal event delivery starts the same stop operation. Its command rejection
+      // repeats the message, so retain the event's severity instead of downgrading
+      // it to an auto-dismissed local error.
+      reportError(describeError(e), get().lastError?.fatal ?? false);
       set({ annotationVisible: false, micSessionMuted: false });
     } finally {
       stopping = false;


### PR DESCRIPTION
# Deliver recorder errors without hiding fatal alerts

Unreadable recorder errors in [issue #47](https://github.com/SECHAK-AG/capptivo/issues/47) led to a multi-pass human-in-the-loop review with agentic coding of the delivery path
This contribution retains fatal alerts and shows a temporary live HUD notice for nonfatal recorder errors

## Contribution map

| Branch | Score | Why it matters | Pull request |
| --- | --- | --- | --- |
| [`fix/windows-crlf-cursor-hotspot-check`](https://github.com/Neonsy/capptivo/tree/fix/windows-crlf-cursor-hotspot-check) | 6/10 | Makes the cursor inventory stable across Windows and Unix line endings | [#59](https://github.com/SECHAK-AG/capptivo/pull/59) |
| [`chore/tooling-ci-release-baseline`](https://github.com/Neonsy/capptivo/tree/chore/tooling-ci-release-baseline) | 10/10 | Pins tooling, verifies sidecars, and constrains CI and release authority | [#60](https://github.com/SECHAK-AG/capptivo/pull/60) |
| [`chore/repository-eol-policy`](https://github.com/Neonsy/capptivo/tree/chore/repository-eol-policy) | 5/10 | Makes repository line endings deliberate across contributors | [#61](https://github.com/SECHAK-AG/capptivo/pull/61) |
| [`chore/dependency-advisories`](https://github.com/Neonsy/capptivo/tree/chore/dependency-advisories) | 8/10 | Removes known JavaScript dependency advisories | [#62](https://github.com/SECHAK-AG/capptivo/pull/62) |
| [`fix/export-file-authority`](https://github.com/Neonsy/capptivo/tree/fix/export-file-authority) | 10/10 | Keeps renderer input from selecting arbitrary export paths | [#63](https://github.com/SECHAK-AG/capptivo/pull/63) |
| [`fix/windows-window-capture`](https://github.com/Neonsy/capptivo/tree/fix/windows-window-capture) | 7/10 | Updates selected-window capture and explains its narrow WGC device limit | [#64](https://github.com/SECHAK-AG/capptivo/pull/64) |
| [`fix/windows-display-affinity-contract`](https://github.com/Neonsy/capptivo/tree/fix/windows-display-affinity-contract) | 9/10 | Fails closed when recording controls cannot be excluded | [#65](https://github.com/SECHAK-AG/capptivo/pull/65) |
| [`fix/structured-local-diagnostics`](https://github.com/Neonsy/capptivo/tree/fix/structured-local-diagnostics) | 8/10 | Stores bounded local failure codes without private event text | [#67](https://github.com/SECHAK-AG/capptivo/pull/67) |
| [`fix/encoder-frame-size-fallback`](https://github.com/Neonsy/capptivo/tree/fix/encoder-frame-size-fallback) | 9/10 | Falls back when a hardware encoder rejects a frame size | [#68](https://github.com/SECHAK-AG/capptivo/pull/68) |

## Delivery behavior

Fatal recorder notices have no auto-dismiss delay and remain until dismissal or a new recording
The existing six-second nonfatal timeout remains in place
A nonfatal event cannot replace a fatal notice, while a later fatal event can replace an earlier fatal

During recording, pause, or finalizing, one nonblank nonfatal message appears as a polite banner above the live controls
The banner uses the compact 448 by 128 `hud-notice` layout, including after a collapsed HUD
The banner is focusable and caps long wrapped content at 74 pixels with scrolling, so controls stay within the native frame
The state clears atomically when the recording leaves a live state or when the existing timeout expires
Fatal errors keep the alert path and never use the HUD notice

## Scope boundary

The branch combines the prior fatal delivery work with the reviewed seven-file live-notice change
It adds no copy or log action
It adds no post-take warning history, persistence, queue, settings, diagnostics, backend notice, or encoder behavior
This partial fix does not claim to close #47

## Evidence and limits

The amended head `e59c83a3f397525d2bf56a082f75f53aee0e7449` is pushed and read back from the fork
The frozen notice snapshot passed offline installation, typecheck, the presentation selfcheck, 47 selfchecks, and frontend build
The exact 612-file composition passed `pnpm test` with 47 selfchecks and 29 cursor assets, plus lint, typecheck, build, and portable Rust formatting
The first full native suite completed with an intermittent warmup-duration failure after 171 passing tests
Three cold-process runs on each of the final, interim, and older archives passed that test
An exact full-suite rerun passed 172 tests with no failures or ignored tests

- [x] The snapshot selfcheck covers live nonfatal delivery, timeout clearing, fatal retention, and fatal replacement
- [x] Static review traced the layout guard that prevents an outgoing HUD from replacing inactive setup or alert layout
- [x] The amended head is pushed and read back with the final 16 contribution heads
- [x] The final composition passed GNU all-target compilation and the exact full-suite rerun
- [ ] Tauri runtime, real capture, desktop alert visibility, and microphone ordering have no proof
- [ ] Run MSVC and hosted CI checks

