### PR TITLE
Store bounded local diagnostic codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,25 @@ cargo check --no-default-features
 
 ---
 
+## Local diagnostics
+
+Capptivo keeps the latest 200 diagnostic codes in `diagnostics/diagnostics-v1.log` under its application-data directory
+Each JSON line contains a Unix timestamp and a fixed code identifying a native, recorder, export, or renderer failure category
+The file contains no error text, file or media names, paths, stack traces, recordings, or device identifiers
+It is not uploaded automatically
+Detailed console output during development remains separate from this file
+
+While not recording, right-click the tray icon and choose **Open Diagnostics…** to locate the file, or **Clear Diagnostics** to empty it
+Only the current diagnostic file is cleared
+Older `logs/errors.log` and `capptivo.*` files are neither imported nor deleted
+The application does not add a warning history to recordings
+
+The file remains local to the current user's application data and is not encrypted
+Older entries are removed as new ones arrive, with no age-based expiration
+Clearing and writing are serialized, but a later failure can create a new entry after a clear
+Writes are best effort, and an interrupted write can lose diagnostic history
+An unavailable application-data path or failed write does not prevent recording and is not redirected to a temporary directory
+
 ## License
 
 Copyright (c) 2026 idboussadel

--- a/src-tauri/src/commands/error_log.rs
+++ b/src-tauri/src/commands/error_log.rs
@@ -1,25 +1,20 @@
-//! Client log IPC — JS errors/info + tray “Open Error Log…” / logs folder.
+//! Client diagnostics IPC with code-only persistence
 
 use crate::error::AppResult;
 use crate::error_log;
 use tauri::AppHandle;
 
-/// Append a frontend error to `errors.log` (and surface as `tracing::error!`).
+/// Persist one allowlisted source code, never the supplied error text
 #[tauri::command(async)]
 pub fn log_client_error(source: String, message: String) -> AppResult<()> {
     if message.trim().is_empty() {
         return Ok(());
     }
-    let src = if source.trim().is_empty() {
-        "js"
-    } else {
-        source.trim()
-    };
-    tracing::error!(target: "js", source = %src, "{message}");
+    error_log::append(error_log::client_error_code(&source));
     Ok(())
 }
 
-/// Append a frontend info line to the rolling `capptivo.log` (not `errors.log`).
+/// Development console information is not persisted to diagnostics
 #[tauri::command(async)]
 pub fn log_client_info(source: String, message: String) -> AppResult<()> {
     if message.trim().is_empty() {
@@ -34,22 +29,22 @@ pub fn log_client_info(source: String, message: String) -> AppResult<()> {
     Ok(())
 }
 
-/// Reveal `logs/errors.log` in Finder / Explorer.
+/// Reveal the code-only diagnostics file in the OS file manager
 #[tauri::command(async)]
 pub fn reveal_error_log(_app: AppHandle) -> AppResult<String> {
     let path = error_log::reveal()?;
     Ok(path.to_string_lossy().into_owned())
 }
 
-/// Reveal the logs folder (`capptivo.*` + `errors.log`).
+/// Reveal the separate diagnostics folder without touching legacy logs
 #[tauri::command(async)]
 pub fn reveal_logs_dir(_app: AppHandle) -> AppResult<String> {
     let path = error_log::reveal_dir()?;
     Ok(path.to_string_lossy().into_owned())
 }
 
-/// Absolute path of the error log (may not exist yet).
+/// Native-owned diagnostics path, which may not exist yet
 #[tauri::command]
 pub fn error_log_path() -> AppResult<String> {
-    Ok(error_log::log_path().to_string_lossy().into_owned())
+    Ok(error_log::log_path()?.to_string_lossy().into_owned())
 }

--- a/src-tauri/src/error_log.rs
+++ b/src-tauri/src/error_log.rs
@@ -1,225 +1,205 @@
-//! Persistent logs for friend installs / support.
-//!
-//! - `{app_data}/logs/capptivo.YYYY-MM-DD` — rolling daily file (`info`/`debug`)
-//! - `{app_data}/logs/errors.log` — `warn`+ / panics / JS `log_client_error`
-//!
-//! Windows: `%APPDATA%\com.capptivo.desktop\logs\…`
-//!
-//! ponytail: file logging currently off in `lib.rs::init_tracing` for release — keep
-//! this module so friend-install diagnostics can be flipped back on without rewrite.
-
-#![allow(dead_code)]
+//! Local, bounded failure codes without event text, paths, or media
 
 use crate::error::{AppError, AppResult};
 use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
 use std::fs::{self, File, OpenOptions};
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
-use tracing::field::{Field, Visit};
 use tracing::{Event, Level, Subscriber};
 use tracing_subscriber::layer::Context;
 use tracing_subscriber::Layer;
 
-const APP_ID: &str = "com.capptivo.desktop";
-const ERROR_LOG_NAME: &str = "errors.log";
-/// Soft cap — rewrite keeping the tail when exceeded.
-const MAX_BYTES: u64 = 2 * 1024 * 1024;
-const KEEP_TAIL: u64 = 512 * 1024;
+const MAX_ENTRIES: usize = 200;
+const MAX_READ_BYTES: u64 = 32 * 1024;
+static LOG: OnceLock<DiagnosticLog> = OnceLock::new();
 
-static LOG_PATH: OnceLock<PathBuf> = OnceLock::new();
-static WRITE_LOCK: Mutex<()> = Mutex::new(());
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Code {
+    NativeWarning,
+    NativeError,
+    NativePanic,
+    RecorderWarning,
+    RecorderError,
+    ExportWarning,
+    ExportError,
+    RendererError,
+    RendererRecorderError,
+    RendererExportError,
+    RendererAnnotationError,
+}
 
-/// Resolve + create the error log file; install panic hook. Safe to call once at boot.
-pub fn init() {
-    let path = default_error_log_path();
-    if let Some(parent) = path.parent() {
-        let _ = fs::create_dir_all(parent);
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct Entry {
+    timestamp: u64,
+    code: Code,
+}
+
+struct DiagnosticLog {
+    path: PathBuf,
+    lock: Mutex<()>,
+}
+
+impl DiagnosticLog {
+    fn new(app_data: &Path) -> Self {
+        Self {
+            path: app_data.join("diagnostics").join("diagnostics-v1.log"),
+            lock: Mutex::new(()),
+        }
     }
-    let _ = LOG_PATH.set(path);
-    let _ = ensure_file();
 
+    fn entries(&self) -> std::io::Result<Vec<Entry>> {
+        let file = match File::open(&self.path) {
+            Ok(file) => file,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(error) => return Err(error),
+        };
+        let mut text = String::new();
+        file.take(MAX_READ_BYTES + 1).read_to_string(&mut text)?;
+        // Do not import oversized or unknown data into the next diagnostic snapshot
+        if text.len() as u64 > MAX_READ_BYTES {
+            return Ok(Vec::new());
+        }
+        Ok(text
+            .lines()
+            .filter_map(|line| serde_json::from_str(line).ok())
+            .collect())
+    }
+
+    fn write(&self, entries: &[Entry]) -> std::io::Result<()> {
+        let parent = self.path.parent().expect("diagnostic path has a parent");
+        fs::create_dir_all(parent)?;
+        let mut options = OpenOptions::new();
+        options.create(true).write(true).truncate(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let mut file = options.open(&self.path)?;
+        for entry in entries {
+            serde_json::to_writer(&mut file, entry)?;
+            file.write_all(b"\n")?;
+        }
+        file.flush()
+    }
+
+    fn append_locked(&self, code: Code) -> std::io::Result<()> {
+        let mut entries = self.entries()?;
+        let keep_from = entries.len().saturating_sub(MAX_ENTRIES - 1);
+        entries.drain(..keep_from);
+        entries.push(Entry {
+            timestamp: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs(),
+            code,
+        });
+        self.write(&entries)
+    }
+
+    fn append(&self, code: Code) -> std::io::Result<()> {
+        let _guard = self.lock.lock();
+        self.append_locked(code)
+    }
+
+    fn clear(&self) -> std::io::Result<()> {
+        let _guard = self.lock.lock();
+        self.write(&[])
+    }
+
+    fn ensure_file(&self) -> std::io::Result<()> {
+        let _guard = self.lock.lock();
+        let mut entries = self.entries()?;
+        entries.drain(..entries.len().saturating_sub(MAX_ENTRIES));
+        self.write(&entries)
+    }
+}
+
+/// Configure after the single-instance lock is acquired, using Tauri's app-data path
+pub fn init(app_data: &Path) {
+    if LOG.set(DiagnosticLog::new(app_data)).is_err() {
+        return;
+    }
     let previous = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
-        let loc = info
-            .location()
-            .map(|l| format!("{}:{}:{}", l.file(), l.line(), l.column()))
-            .unwrap_or_else(|| "unknown".into());
-        let payload = if let Some(s) = info.payload().downcast_ref::<&str>() {
-            (*s).to_string()
-        } else if let Some(s) = info.payload().downcast_ref::<String>() {
-            s.clone()
-        } else {
-            "Box<Any>".into()
-        };
-        append_line("ERROR", "panic", &format!("{payload} @ {loc}"));
+        if let Some(log) = LOG.get() {
+            // A panic during a log write must not deadlock its own hook
+            if let Some(_guard) = log.lock.try_lock() {
+                let _ = log.append_locked(Code::NativePanic);
+            }
+        }
         previous(info);
     }));
 }
 
-/// Directory that holds `capptivo.*` and `errors.log`.
-pub fn logs_dir() -> PathBuf {
-    app_data_root().join("logs")
+fn configured() -> AppResult<&'static DiagnosticLog> {
+    LOG.get()
+        .ok_or_else(|| AppError::Other("local diagnostics are unavailable".into()))
 }
 
-pub fn log_path() -> PathBuf {
-    LOG_PATH.get().cloned().unwrap_or_else(default_error_log_path)
+pub fn log_path() -> AppResult<PathBuf> {
+    Ok(configured()?.path.clone())
 }
 
-/// Append one error line. Never panics; failures are silent.
-pub fn append(source: &str, message: &str) {
-    append_line("ERROR", source, message);
-}
-
-fn append_line(level: &str, source: &str, message: &str) {
-    let msg = message.trim();
-    if msg.is_empty() {
-        return;
-    }
-    let line = format!(
-        "{} {} [{}] {}\n",
-        chrono::Utc::now().format("%Y-%m-%dT%H:%M:%S%.3fZ"),
-        level,
-        sanitize(source),
-        sanitize_message(msg),
-    );
-    let _guard = WRITE_LOCK.lock();
-    let path = log_path();
-    if let Some(parent) = path.parent() {
-        let _ = fs::create_dir_all(parent);
-    }
-    rotate_if_huge(&path);
-    if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(&path) {
-        let _ = file.write_all(line.as_bytes());
-        let _ = file.flush();
+pub fn append(code: Code) {
+    if let Some(log) = LOG.get() {
+        // Diagnostics never turn a successful operation into a failure
+        let _ = log.append(code);
     }
 }
 
-/// Reveal `errors.log` in the OS file manager. Creates an empty file if missing.
+pub fn client_error_code(source: &str) -> Code {
+    match source.split(':').next().unwrap_or_default() {
+        "recorder" => Code::RendererRecorderError,
+        "export" => Code::RendererExportError,
+        "annotation" | "annotation-overlay" => Code::RendererAnnotationError,
+        _ => Code::RendererError,
+    }
+}
+
+pub fn clear() -> AppResult<()> {
+    configured()?.clear()?;
+    Ok(())
+}
+
 pub fn reveal() -> AppResult<PathBuf> {
-    let path = ensure_file()?;
-    opener_reveal(&path)?;
-    Ok(path)
+    let log = configured()?;
+    log.ensure_file()?;
+    opener_reveal(&log.path)?;
+    Ok(log.path.clone())
 }
 
-/// Reveal the logs folder (both `capptivo.*` and `errors.log`).
+/// Existing IPC alias now reveals only the separate structured diagnostics folder
 pub fn reveal_dir() -> AppResult<PathBuf> {
-    let dir = logs_dir();
-    fs::create_dir_all(&dir)?;
-    let _ = ensure_file();
-    opener_reveal_dir(&dir)?;
-    Ok(dir)
-}
-
-fn ensure_file() -> AppResult<PathBuf> {
-    let path = log_path();
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
-    }
-    if !path.exists() {
-        File::create(&path)?;
-    }
-    Ok(path)
-}
-
-fn default_error_log_path() -> PathBuf {
-    logs_dir().join(ERROR_LOG_NAME)
-}
-
-fn app_data_root() -> PathBuf {
-    #[cfg(target_os = "windows")]
-    {
-        if let Some(appdata) = std::env::var_os("APPDATA") {
-            return PathBuf::from(appdata).join(APP_ID);
-        }
-    }
-    #[cfg(target_os = "macos")]
-    {
-        if let Some(home) = std::env::var_os("HOME") {
-            return PathBuf::from(home)
-                .join("Library")
-                .join("Application Support")
-                .join(APP_ID);
-        }
-    }
-    #[cfg(target_os = "linux")]
-    {
-        if let Some(xdg) = std::env::var_os("XDG_DATA_HOME") {
-            return PathBuf::from(xdg).join(APP_ID);
-        }
-        if let Some(home) = std::env::var_os("HOME") {
-            return PathBuf::from(home)
-                .join(".local")
-                .join("share")
-                .join(APP_ID);
-        }
-    }
-    std::env::temp_dir().join("Capptivo").join(APP_ID)
-}
-
-fn rotate_if_huge(path: &Path) {
-    let Ok(meta) = fs::metadata(path) else {
-        return;
-    };
-    if meta.len() <= MAX_BYTES {
-        return;
-    }
-    let Ok(data) = fs::read(path) else {
-        return;
-    };
-    let start = data.len().saturating_sub(KEEP_TAIL as usize);
-    let mut tail = data[start..].to_vec();
-    if let Some(i) = tail.iter().position(|&b| b == b'\n') {
-        tail = tail[i + 1..].to_vec();
-    }
-    let _ = fs::write(path, tail);
-}
-
-fn sanitize(s: &str) -> String {
-    s.chars()
-        .map(|c| if c.is_control() { ' ' } else { c })
-        .take(64)
-        .collect()
-}
-
-fn sanitize_message(s: &str) -> String {
-    s.chars()
-        .map(|c| match c {
-            '\n' | '\r' => ' ',
-            c if c.is_control() => ' ',
-            c => c,
-        })
-        .take(4000)
-        .collect()
+    let path = reveal()?;
+    Ok(path
+        .parent()
+        .expect("diagnostic path has a parent")
+        .to_path_buf())
 }
 
 fn opener_reveal(path: &Path) -> AppResult<()> {
     #[cfg(target_os = "macos")]
-    {
-        std::process::Command::new("open")
-            .args(["-R"])
-            .arg(path)
-            .spawn()
-            .map_err(|e| AppError::Other(format!("reveal log failed: {e}")))?;
-        return Ok(());
-    }
+    let result = std::process::Command::new("open")
+        .arg("-R")
+        .arg(path)
+        .spawn();
     #[cfg(target_os = "windows")]
-    {
-        std::process::Command::new("explorer")
-            .arg(format!("/select,{}", path.display()))
-            .spawn()
-            .map_err(|e| AppError::Other(format!("reveal log failed: {e}")))?;
-        return Ok(());
-    }
+    let result = std::process::Command::new("explorer")
+        .arg(format!("/select,{}", path.display()))
+        .spawn();
     #[cfg(target_os = "linux")]
+    let result = std::process::Command::new("xdg-open")
+        .arg(path.parent().expect("diagnostic path has a parent"))
+        .spawn();
+    #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
     {
-        if let Some(parent) = path.parent() {
-            std::process::Command::new("xdg-open")
-                .arg(parent)
-                .spawn()
-                .map_err(|e| AppError::Other(format!("reveal log failed: {e}")))?;
-        }
-        return Ok(());
+        result.map_err(|_| AppError::Other("could not open local diagnostics".into()))?;
+        Ok(())
     }
     #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
     {
@@ -228,111 +208,224 @@ fn opener_reveal(path: &Path) -> AppResult<()> {
     }
 }
 
-fn opener_reveal_dir(dir: &Path) -> AppResult<()> {
-    #[cfg(target_os = "macos")]
-    {
-        std::process::Command::new("open")
-            .arg(dir)
-            .spawn()
-            .map_err(|e| AppError::Other(format!("reveal logs dir failed: {e}")))?;
-        return Ok(());
-    }
-    #[cfg(target_os = "windows")]
-    {
-        std::process::Command::new("explorer")
-            .arg(dir)
-            .spawn()
-            .map_err(|e| AppError::Other(format!("reveal logs dir failed: {e}")))?;
-        return Ok(());
-    }
-    #[cfg(target_os = "linux")]
-    {
-        std::process::Command::new("xdg-open")
-            .arg(dir)
-            .spawn()
-            .map_err(|e| AppError::Other(format!("reveal logs dir failed: {e}")))?;
-        return Ok(());
-    }
-    #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
-    {
-        let _ = dir;
-        Err(AppError::Unsupported)
-    }
-}
-
-/// Tracing layer: [`Level::WARN`] and [`Level::ERROR`] hit `errors.log`.
 pub struct ErrorFileLayer;
 
-impl<S> Layer<S> for ErrorFileLayer
-where
-    S: Subscriber,
-{
+fn event_code(event: &Event<'_>) -> Option<Code> {
+    let metadata = event.metadata();
+    let warning = match *metadata.level() {
+        Level::WARN => true,
+        Level::ERROR => false,
+        _ => return None,
+    };
+    // Never visit event fields, messages, spans, or arbitrary source text
+    let target = metadata.target();
+    Some(if target.starts_with("desktop_lib::recorder::") {
+        if warning {
+            Code::RecorderWarning
+        } else {
+            Code::RecorderError
+        }
+    } else if target.starts_with("desktop_lib::export_")
+        || target == "desktop_lib::commands::export"
+    {
+        if warning {
+            Code::ExportWarning
+        } else {
+            Code::ExportError
+        }
+    } else if warning {
+        Code::NativeWarning
+    } else {
+        Code::NativeError
+    })
+}
+
+impl<S: Subscriber> Layer<S> for ErrorFileLayer {
     fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
-        let level = *event.metadata().level();
-        // tracing Ord: ERROR > WARN > INFO — keep warn+.
-        if level < Level::WARN {
-            return;
+        if let Some(code) = event_code(event) {
+            append(code);
         }
-        let level_label = if level == Level::ERROR { "ERROR" } else { "WARN" };
-        let mut visitor = ErrorVisitor::default();
-        event.record(&mut visitor);
-        let target = event.metadata().target();
-        let msg = if visitor.message.is_empty() {
-            visitor.fields
-        } else if visitor.fields.is_empty() {
-            visitor.message
-        } else {
-            format!("{} {}", visitor.message, visitor.fields)
-        };
-        append_line(level_label, target, &msg);
-    }
-}
-
-#[derive(Default)]
-struct ErrorVisitor {
-    message: String,
-    fields: String,
-}
-
-impl Visit for ErrorVisitor {
-    fn record_str(&mut self, field: &Field, value: &str) {
-        if field.name() == "message" {
-            self.message = value.to_string();
-        } else {
-            self.push_field(field.name(), value);
-        }
-    }
-
-    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
-        if field.name() == "message" {
-            self.message = format!("{value:?}");
-            if self.message.starts_with('"') && self.message.ends_with('"') && self.message.len() >= 2
-            {
-                self.message = self.message[1..self.message.len() - 1].to_string();
-            }
-        } else {
-            self.push_field(field.name(), &format!("{value:?}"));
-        }
-    }
-}
-
-impl ErrorVisitor {
-    fn push_field(&mut self, name: &str, value: &str) {
-        if !self.fields.is_empty() {
-            self.fields.push(' ');
-        }
-        self.fields.push_str(name);
-        self.fields.push('=');
-        self.fields.push_str(value);
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+    use tracing_subscriber::prelude::*;
+
+    fn fixture() -> (PathBuf, DiagnosticLog) {
+        let dir =
+            std::env::temp_dir().join(format!("capptivo-diagnostics-{}", uuid::Uuid::new_v4()));
+        let log = DiagnosticLog::new(&dir);
+        (dir, log)
+    }
 
     #[test]
-    fn sanitize_strips_newlines() {
-        assert!(!sanitize_message("a\nb\rc").contains('\n'));
+    fn registered_layer_and_client_command_persist_only_codes() {
+        const CHILD: &str = "CAPPTIVO_DIAGNOSTICS_TEST_CHILD";
+        if let Some(dir) = std::env::var_os(CHILD) {
+            let dir = PathBuf::from(dir);
+            init(&dir);
+            crate::init_tracing();
+            tracing::error!(path = "private-fixture.mov", "private fixture text");
+            crate::commands::error_log::log_client_error(
+                "recorder:private-fixture".into(),
+                "private fixture text".into(),
+            )
+            .unwrap();
+            crate::commands::error_log::log_client_info(
+                "private-fixture".into(),
+                "private fixture text".into(),
+            )
+            .unwrap();
+            let log = configured().unwrap();
+            let entries = log.entries().unwrap();
+            assert_eq!(
+                entries.iter().map(|entry| entry.code).collect::<Vec<_>>(),
+                vec![Code::NativeError, Code::RendererRecorderError]
+            );
+            let text = fs::read_to_string(&log.path).unwrap();
+            assert!(!text.contains("private"));
+            clear().unwrap();
+            assert_eq!(fs::metadata(log_path().unwrap()).unwrap().len(), 0);
+            return;
+        }
+        let (dir, _) = fixture();
+        let mut child = crate::proc::command(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "error_log::tests::registered_layer_and_client_command_persist_only_codes",
+            ])
+            .env(CHILD, &dir)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .unwrap();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        let status = loop {
+            if let Some(status) = child.try_wait().unwrap() {
+                break status;
+            }
+            if std::time::Instant::now() >= deadline {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!("diagnostics child did not finish");
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        };
+        assert!(status.success(), "diagnostics child failed: {status}");
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn keeps_latest_codes_and_clear_preserves_unrelated_files() {
+        let (dir, log) = fixture();
+        fs::create_dir_all(dir.join("logs")).unwrap();
+        let legacy = dir.join("logs/errors.log");
+        fs::write(&legacy, "legacy diagnostic fixture").unwrap();
+        log.append(Code::NativePanic).unwrap();
+        for _ in 0..MAX_ENTRIES {
+            log.append(Code::RecorderError).unwrap();
+        }
+        let entries = log.entries().unwrap();
+        assert_eq!(entries.len(), MAX_ENTRIES);
+        assert!(entries
+            .iter()
+            .all(|entry| entry.code == Code::RecorderError));
+        assert!(fs::metadata(&log.path).unwrap().len() < MAX_READ_BYTES);
+        log.clear().unwrap();
+        assert!(log.entries().unwrap().is_empty());
+        assert_eq!(
+            fs::read_to_string(legacy).unwrap(),
+            "legacy diagnostic fixture"
+        );
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn malformed_or_unknown_rows_are_not_copied_forward() {
+        let (dir, log) = fixture();
+        log.ensure_file().unwrap();
+        fs::write(
+            &log.path,
+            concat!(
+                "{\"timestamp\":1,\"code\":\"native_error\"}\n",
+                "{\"timestamp\":2,\"code\":\"private-fixture\"}\n",
+                "{\"timestamp\":3,\"code\":\"native_error\",\"message\":\"private-fixture\"}\n",
+                "{\"timestamp\":4"
+            ),
+        )
+        .unwrap();
+        log.append(Code::NativeWarning).unwrap();
+        assert_eq!(log.entries().unwrap().len(), 2);
+        assert!(!fs::read_to_string(&log.path)
+            .unwrap()
+            .contains("private-fixture"));
+        fs::write(&log.path, vec![b'x'; MAX_READ_BYTES as usize + 1]).unwrap();
+        log.append(Code::NativeError).unwrap();
+        assert_eq!(log.entries().unwrap().len(), 1);
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn concurrent_writes_and_clear_leave_only_complete_bounded_rows() {
+        let (dir, log) = fixture();
+        let log = Arc::new(log);
+        std::thread::scope(|scope| {
+            for _ in 0..4 {
+                let log = Arc::clone(&log);
+                scope.spawn(move || {
+                    for _ in 0..75 {
+                        log.append(Code::NativeError).unwrap();
+                    }
+                });
+            }
+            let log = Arc::clone(&log);
+            scope.spawn(move || log.clear().unwrap());
+        });
+        let text = fs::read_to_string(&log.path).unwrap();
+        assert!(text.lines().count() <= MAX_ENTRIES);
+        for line in text.lines() {
+            serde_json::from_str::<Entry>(line).unwrap();
+        }
+        log.clear().unwrap();
+        assert_eq!(fs::metadata(&log.path).unwrap().len(), 0);
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn trace_fields_are_never_formatted_and_info_is_ignored() {
+        struct PrivateField;
+        impl std::fmt::Debug for PrivateField {
+            fn fmt(&self, _: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                panic!("diagnostic layer must not read fields");
+            }
+        }
+        struct Capture(Arc<Mutex<Vec<Code>>>);
+        impl<S: Subscriber> Layer<S> for Capture {
+            fn on_event(&self, event: &Event<'_>, _: Context<'_, S>) {
+                if let Some(code) = event_code(event) {
+                    self.0.lock().push(code);
+                }
+            }
+        }
+        let codes = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::registry().with(Capture(Arc::clone(&codes)));
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::info!(private = ?PrivateField, "ignored");
+            tracing::warn!(target: "desktop_lib::recorder::encoder", private = ?PrivateField, "not recorded");
+            tracing::error!(target: "desktop_lib::commands::export", private = ?PrivateField, "not recorded");
+        });
+        assert_eq!(
+            *codes.lock(),
+            vec![Code::RecorderWarning, Code::ExportError]
+        );
+        assert_eq!(
+            client_error_code("recorder:private-fixture"),
+            Code::RendererRecorderError
+        );
+        assert_eq!(client_error_code("private-fixture"), Code::RendererError);
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -73,11 +73,6 @@ mod windows;
 use state::AppState;
 use tauri::Manager;
 
-// ponytail: file logging disabled for release — re-enable with the block in `init_tracing`.
-// use std::sync::OnceLock;
-// use tracing_appender::non_blocking::WorkerGuard;
-// static LOG_GUARD: OnceLock<WorkerGuard> = OnceLock::new();
-
 /// Global start/stop-and-show hotkey for the recorder popover.
 const RECORDER_HOTKEY: &str = "Alt+Shift+R";
 
@@ -109,6 +104,11 @@ pub fn run() {
         })
         .setup(|app| {
             let handle = app.handle().clone();
+            // The single-instance plugin has acquired the application lock
+            // Diagnostics stay disabled if the canonical app-data path is unavailable
+            if let Ok(app_data) = handle.path().app_data_dir() {
+                error_log::init(&app_data);
+            }
             app.manage(AppState::build(&handle));
             app.manage(area_picker::AreaPickState::new());
             tray::build(&handle)?;
@@ -183,33 +183,12 @@ fn init_tracing() {
     use tracing_subscriber::prelude::*;
     use tracing_subscriber::EnvFilter;
 
-    // ponytail: persistent file logs + errors.log off for release builds.
-    // Uncomment the block below (and LOG_GUARD above) to re-enable friend-install diagnostics.
-    //
-    // use tracing_subscriber::filter::LevelFilter;
-    // crate::error_log::init();
-    // let dir = crate::error_log::logs_dir();
-    // let _ = std::fs::create_dir_all(&dir);
-    // let file_appender = tracing_appender::rolling::daily(&dir, "capptivo");
-    // let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
-    // let _ = LOG_GUARD.set(guard);
-    // let rolling_filter = EnvFilter::new(&env);
-
     let env = std::env::var("RUST_LOG").unwrap_or_else(|_| "info,desktop_lib=debug".into());
     let console_filter = EnvFilter::new(&env);
 
-    // Console only (`tauri dev` / stderr). No on-disk `capptivo.*` / `errors.log`.
+    // Console details remain separate from the code-only persistent layer
     let _ = tracing_subscriber::registry()
         .with(fmt::layer().with_target(false).with_filter(console_filter))
-        // .with(
-        //     fmt::layer()
-        //         .with_ansi(false)
-        //         .with_target(true)
-        //         .with_writer(non_blocking)
-        //         .with_filter(rolling_filter),
-        // )
-        // .with(crate::error_log::ErrorFileLayer.with_filter(LevelFilter::WARN))
+        .with(crate::error_log::ErrorFileLayer)
         .try_init();
-
-    // tracing::info!(dir = %dir.display(), "file logging enabled");
 }

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -13,6 +13,7 @@ use tauri::image::Image;
 use tauri::menu::{Menu, MenuItem, PredefinedMenuItem};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
 use tauri::{AppHandle, Manager};
+use tauri_plugin_dialog::{DialogExt, MessageDialogKind};
 
 pub const TRAY_ID: &str = "capptivo-tray";
 
@@ -87,9 +88,20 @@ fn idle_menu(app: &AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
         MenuItem::with_id(app, "annotate", "Annotate Screen…", true, None::<&str>)?;
     let open_library = MenuItem::with_id(app, "open_library", "Recordings…", true, None::<&str>)?;
     let settings = MenuItem::with_id(app, "settings", "Settings…", true, None::<&str>)?;
-    // ponytail: "Open Logs…" disabled with file logging for release — uncomment with init_tracing.
-    // let open_logs =
-    //     MenuItem::with_id(app, "open_logs", "Open Logs…", true, None::<&str>)?;
+    let open_diagnostics = MenuItem::with_id(
+        app,
+        "open_diagnostics",
+        "Open Diagnostics…",
+        true,
+        None::<&str>,
+    )?;
+    let clear_diagnostics = MenuItem::with_id(
+        app,
+        "clear_diagnostics",
+        "Clear Diagnostics",
+        true,
+        None::<&str>,
+    )?;
     let check_updates =
         MenuItem::with_id(app, "check_updates", "Check for Updates…", true, None::<&str>)?;
     let separator = PredefinedMenuItem::separator(app)?;
@@ -102,7 +114,8 @@ fn idle_menu(app: &AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
             &open_library,
             &settings,
             &separator,
-            // &open_logs,
+            &open_diagnostics,
+            &clear_diagnostics,
             &check_updates,
             &separator,
             &quit,
@@ -192,12 +205,22 @@ fn on_menu_event(app: &AppHandle, event: tauri::menu::MenuEvent) {
                 tracing::warn!(%e, "failed to open recordings library");
             }
         }
-        // ponytail: disabled with file logging for release.
-        // "open_logs" => {
-        //     if let Err(e) = crate::error_log::reveal_dir() {
-        //         tracing::error!(%e, "failed to reveal logs folder");
-        //     }
-        // }
+        "open_diagnostics" => {
+            if crate::error_log::reveal().is_err() {
+                app.dialog()
+                    .message("Could not open local diagnostics")
+                    .kind(MessageDialogKind::Error)
+                    .show(|_| {});
+            }
+        }
+        "clear_diagnostics" => {
+            if crate::error_log::clear().is_err() {
+                app.dialog()
+                    .message("Could not clear local diagnostics")
+                    .kind(MessageDialogKind::Error)
+                    .show(|_| {});
+            }
+        }
         "settings" => {
             // Settings window is a Phase 5 item; open the popover for now.
             let _ = windows::show_recorder_popover(app);

--- a/src/ipc/bindings.ts
+++ b/src/ipc/bindings.ts
@@ -248,15 +248,15 @@ export const commands = {
     invoke<void>("attach_export_audio", args),
   removeTempFile: (args: { path: string }) =>
     invoke<void>("remove_temp_file", args),
-  /** Append one error line to `errors.log`. */
+  /** Persist an allowlisted source code, never the supplied error text */
   logClientError: (source: string, message: string) =>
     invoke<void>("log_client_error", { source, message }),
-  /** Append one info line to rolling `capptivo.log` (not `errors.log`). */
+  /** Development console information, not persisted to diagnostics */
   logClientInfo: (source: string, message: string) =>
     invoke<void>("log_client_info", { source, message }),
-  /** Reveal `logs/errors.log` in Finder / Explorer. */
+  /** Reveal the native-owned code-only diagnostics file */
   revealErrorLog: () => invoke<string>("reveal_error_log"),
-  /** Reveal the logs folder (`capptivo.*` + `errors.log`). */
+  /** Reveal the separate diagnostics folder without touching legacy logs */
   revealLogsDir: () => invoke<string>("reveal_logs_dir"),
   errorLogPath: () => invoke<string>("error_log_path"),
 } as const;

--- a/src/lib/errorLogging.ts
+++ b/src/lib/errorLogging.ts
@@ -1,7 +1,7 @@
 /**
- * Persist JS diagnostics to on-disk logs.
- * - `logClientError` → `errors.log` (+ tracing error)
- * - `logClientInfo` → rolling `capptivo.log` (info only; targeted call sites)
+ * Native diagnostics persist only an allowlisted code for each error source
+ * Error text is not written to the diagnostics file
+ * Info messages go only to the development console
  */
 
 import { commands } from "../ipc/bindings";
@@ -26,14 +26,14 @@ function describe(e: unknown): string {
 
 let installed = false;
 
-/** Fire-and-forget append to `errors.log`; never throws into UI. */
+/** Fire-and-forget diagnostic code, never throws into UI */
 export function logClientError(source: string, error: unknown): void {
   const message = describe(error);
   if (!message) return;
   void commands.logClientError(source, message).catch(() => undefined);
 }
 
-/** Fire-and-forget info line into rolling `capptivo.log`. */
+/** Fire-and-forget development console information, not persisted */
 export function logClientInfo(source: string, message: string): void {
   const msg = message.trim();
   if (!msg) return;


### PR DESCRIPTION
# Store bounded local diagnostic codes

Local failure reports need inspectable categories without private event text, as established through a multi-pass human-in-the-loop review with agentic coding
It limits the stored record to a timestamp and a fixed code while preserving recording when storage is unavailable

## Contribution map

| Branch | Score | Why it matters | Pull request |
| --- | --- | --- | --- |
| [`fix/windows-crlf-cursor-hotspot-check`](https://github.com/Neonsy/capptivo/tree/fix/windows-crlf-cursor-hotspot-check) | 6/10 | Makes the cursor inventory stable across Windows and Unix line endings | [#59](https://github.com/SECHAK-AG/capptivo/pull/59) |
| [`chore/tooling-ci-release-baseline`](https://github.com/Neonsy/capptivo/tree/chore/tooling-ci-release-baseline) | 10/10 | Pins tooling, verifies sidecars, and constrains CI and release authority | [#60](https://github.com/SECHAK-AG/capptivo/pull/60) |
| [`chore/repository-eol-policy`](https://github.com/Neonsy/capptivo/tree/chore/repository-eol-policy) | 5/10 | Makes repository line endings deliberate across contributors | [#61](https://github.com/SECHAK-AG/capptivo/pull/61) |
| [`chore/dependency-advisories`](https://github.com/Neonsy/capptivo/tree/chore/dependency-advisories) | 8/10 | Removes known JavaScript dependency advisories | [#62](https://github.com/SECHAK-AG/capptivo/pull/62) |
| [`fix/export-file-authority`](https://github.com/Neonsy/capptivo/tree/fix/export-file-authority) | 10/10 | Keeps renderer input from selecting arbitrary export paths | [#63](https://github.com/SECHAK-AG/capptivo/pull/63) |
| [`fix/windows-window-capture`](https://github.com/Neonsy/capptivo/tree/fix/windows-window-capture) | 7/10 | Updates selected-window capture and explains its narrow WGC device limit | [#64](https://github.com/SECHAK-AG/capptivo/pull/64) |
| [`fix/windows-display-affinity-contract`](https://github.com/Neonsy/capptivo/tree/fix/windows-display-affinity-contract) | 9/10 | Fails closed when recording controls cannot be excluded | [#65](https://github.com/SECHAK-AG/capptivo/pull/65) |
| [`fix/recorder-error-delivery`](https://github.com/Neonsy/capptivo/tree/fix/recorder-error-delivery) | 8/10 | Keeps fatal alerts visible and shows live nonfatal recorder notices | [#66](https://github.com/SECHAK-AG/capptivo/pull/66) |
| [`fix/encoder-frame-size-fallback`](https://github.com/Neonsy/capptivo/tree/fix/encoder-frame-size-fallback) | 9/10 | Falls back when a hardware encoder rejects a frame size | [#68](https://github.com/SECHAK-AG/capptivo/pull/68) |

## Stored data and access

The app writes at most 200 JSON lines to `diagnostics/diagnostics-v1.log` under its application-data directory
Each line holds a Unix timestamp and a finite code for native, recorder, export, or renderer failures
It never serializes event fields, messages, spans, sources, file names, paths, recordings, device identifiers, or client error text
Malformed, unknown, and oversized existing input is not copied forward

The tray exposes **Open Diagnostics…** and **Clear Diagnostics** only while idle
Clear affects the current diagnostics file only
The app does not import, delete, or expose legacy `logs/errors.log` or `capptivo.*` files
It does not add warning history to recordings
Failed storage remains local and best effort, so recording continues without a temporary fallback
Entries have no age-based expiry
An interrupted write can truncate or lose diagnostic history

## Evidence and remaining checks

The signed head `f128c88ae0b2fe715ffbd89e62ad7e4b53c53197` is pushed and read back from the fork
The frozen seven-file snapshot passed offline installation, `pnpm test`, typecheck, and build
Lint retains the inherited `src/annotation/engine.ts:948` finding
The reviewed native test initializes the real layer and client command in a clean subprocess, persists only fixed codes, rejects private fixture text, and verifies clear leaves an empty file
The exact 612-file composition passed `pnpm test` with 47 selfchecks and 29 cursor assets, plus lint, typecheck, build, and portable Rust formatting
The first full native suite completed with an intermittent warmup-duration failure after 171 passing tests
Three cold-process runs on each of the final, interim, and older archives passed that test
An exact full-suite rerun passed 172 tests with no failures or ignored tests

- [x] Review found no blocker in the bounded schema, mutex access, app-data ownership, tray controls, or client command path
- [x] The frozen frontend snapshot kept all seven source files and package metadata unchanged during validation
- [x] The main-based head is pushed and read back with the final 16 contribution heads
- [x] The final composition passed GNU all-target compilation and the exact full-suite rerun
- [ ] Run MSVC, desktop runtime, and hosted CI checks

