### PR TITLE
Update selected-window capture and explain a narrow WGC device limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,11 @@ Platform notes:
 
 - **macOS** captures through native **ScreenCaptureKit** with **VideoToolbox** hardware
   H.264 encoding; system audio comes from a companion SCK stream.
-- **Windows** captures through native **Windows.Graphics.Capture**, with hardware
-  encoding probed per machine (NVENC / QuickSync / AMF / Media Foundation) and
-  system audio via **WASAPI loopback**.
+- **Windows** captures through native **Windows.Graphics.Capture**.
+  Capptivo's current Windows capture backend requires Direct3D feature level
+  11_0 or later on the hardware adapter Windows selects by default.
+  Hardware encoding is probed per machine (NVENC / QuickSync / AMF / Media
+  Foundation), with system audio via **WASAPI loopback**.
 - **Linux** captures through **xdg-desktop-portal + PipeWire** — the screen/window is
   picked in the system dialog. System audio comes from the PulseAudio/PipeWire
   monitor. Cursor replay / follow-zoom use an X11 pointer probe on X11 sessions,

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1034,7 +1034,7 @@ dependencies = [
  "ureq",
  "uuid",
  "windows 0.62.2",
- "windows-capture 2.0.0",
+ "windows-capture 2.0.1",
  "x11rb",
 ]
 
@@ -5846,9 +5846,9 @@ dependencies = [
 
 [[package]]
 name = "windows-capture"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9460c7b82f6b7d314d85b45610481f26a1159a42dadf1e13a329041553e060"
+checksum = "09046acbe9b6d039cde50e8c8178d95bb0f9b33ed7feccc4465dadc5404b31b4"
 dependencies = [
  "parking_lot",
  "rayon",

--- a/src-tauri/src/recorder/backend/wgc_backend.rs
+++ b/src-tauri/src/recorder/backend/wgc_backend.rs
@@ -25,7 +25,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use windows::Win32::Graphics::Gdi::HMONITOR;
-use windows_capture::capture::{Context, GraphicsCaptureApiHandler};
+use windows_capture::capture::{Context, GraphicsCaptureApiError, GraphicsCaptureApiHandler};
+use windows_capture::d3d11::Error as DirectXError;
 use windows_capture::frame::Frame;
 use windows_capture::graphics_capture_api::{GraphicsCaptureApi, InternalCaptureControl};
 use windows_capture::monitor::Monitor;
@@ -37,6 +38,21 @@ use windows_capture::window::Window;
 
 /// Sources smaller than this are noise (tooltips, hidden helpers), not targets.
 const MIN_WINDOW_SIDE: i32 = 96;
+
+fn map_wgc_start_error<E: std::fmt::Display>(error: GraphicsCaptureApiError<E>) -> AppError {
+    match error {
+        GraphicsCaptureApiError::DirectXError(DirectXError::FeatureLevelNotSatisfied) => {
+            AppError::Other(
+                "failed to start Windows capture: this capture backend requires Direct3D feature \
+                 level 11_0 or later on the hardware adapter Windows selects by default. The \
+                 selected adapter returned a lower level. Ensure a compatible graphics driver is \
+                 installed and enabled, or use compatible graphics hardware"
+                    .into(),
+            )
+        }
+        error => AppError::Other(format!("failed to start WGC capture: {error}")),
+    }
+}
 
 pub struct WgcBackend;
 
@@ -197,7 +213,7 @@ impl CaptureBackend for WgcBackend {
                 flags,
             )),
         }
-        .map_err(|e| AppError::Other(format!("failed to start WGC capture: {e}")))?;
+        .map_err(map_wgc_start_error)?;
 
         // First frame carries the exact output size (crop-adjusted) plus the
         // timestamp epoch the forwarder anchored at session start.
@@ -535,5 +551,37 @@ impl GraphicsCaptureApiHandler for FrameForwarder {
         // Captured window closed: dropping the sender disconnects the channel,
         // which ends the encode loop cleanly with whatever was recorded.
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn feature_level_failure_names_requirement_and_remediation() {
+        let error =
+            GraphicsCaptureApiError::<String>::DirectXError(DirectXError::FeatureLevelNotSatisfied);
+
+        assert_eq!(
+            map_wgc_start_error(error).to_string(),
+            "failed to start Windows capture: this capture backend requires Direct3D feature \
+             level 11_0 or later on the hardware adapter Windows selects by default. The selected \
+             adapter returned a lower level. Ensure a compatible graphics driver is installed and \
+             enabled, or use compatible graphics hardware"
+        );
+    }
+
+    #[test]
+    fn other_directx_failure_keeps_dependency_error() {
+        let error = GraphicsCaptureApiError::<String>::DirectXError(
+            DirectXError::UnexpectedNullResult("an ID3D11Device"),
+        );
+
+        assert_eq!(
+            map_wgc_start_error(error).to_string(),
+            "failed to start WGC capture: DirectX error: Windows API succeeded but did not return \
+             an ID3D11Device"
+        );
     }
 }


### PR DESCRIPTION
Reopened from https://github.com/SECHAK-AG/capptivo/pull/64 (original fork deleted).